### PR TITLE
configure.ac.tpl: define _DEFAULT_SOURCE on linux

### DIFF
--- a/configure.ac.tpl
+++ b/configure.ac.tpl
@@ -15,7 +15,7 @@ case $target_os in
 		;;
 	*linux*)
 		TARGET_OS=linux;
-		CFLAGS="$CFLAGS -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE"
+		CFLAGS="$CFLAGS -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE"
 		AC_SUBST([PLATFORM_LDADD], ['-lrt'])
 		;;
 	*solaris*)


### PR DESCRIPTION
This is needed to build on newer glibc (glibc-headers-2.19.90-23.fc21.x86_64 on Fedora rawhide)
