### PR TITLE
update stdio.h for including stdarg.h

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -4,6 +4,7 @@
 #define LIBCRYPTOCOMPAT_STDIO_H
 
 #ifdef NO_ASPRINTF
+#include <stdarg.h>
 int vasprintf(char **str, const char *fmt, va_list ap);
 int asprintf(char **str, const char *fmt, ...);
 #endif


### PR DESCRIPTION
it seems that including stdarg.h is needed for defining va_list
environment is hpux 11.31(ia64) with gcc 4.7.1.

without stdarg.h, I got compilation error like this.
  "error: 'va_list' undeclared (first use in this function)"

I checked with gcc -E, then I noticed that __va_list is defined but va_list is not.
  "typedef __gnuc_va_list __va_list;"

with including stdarg.h, va_list is defined.
  "typedef __gnuc_va_list va_list;"
