### PR TITLE
OpenSSL compatible ./config wrapper

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,11 @@
+#!/bin/sh
+ARGS=""
+for var in "$@"; do
+    case $var in
+        no-shared ) ARGS="$ARGS --disable-shared";;
+        no-asm    ) ARGS="$ARGS --disable-asm";;
+        --prefix* ) ARGS="$ARGS $var";;
+    esac
+done
+
+./configure $ARGS


### PR DESCRIPTION
OpenSSL, for some reason, uses the ./config command to prepare its installation. This script is called directly by at least one application.

I have operated Nginx 1.7.5 linked statically against Libressl-portable on CentOS 6.5, and this is the one issue that currently needs patching out as part of that process.

By adding the thin wrapper included in this PR, libressl-portable becomes truly "drop-in" for this scenario and, I would imagine, many others.
