### PR TITLE
update.sh: do not mark GNU_STACK WX in ELFs generated from assembly

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -125,10 +125,20 @@ $CP crypto/compat/ui_openssl_win.c crypto/ui
 asm_src=$libssl_src/src/crypto
 gen_asm_stdout() {
 	perl $asm_src/$2 $1 > $3.tmp
+	[[ $1 == "elf" ]] && cat <<-EOF >> $3.tmp
+	#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+	#endif
+	EOF
 	$MV $3.tmp $3
 }
 gen_asm() {
 	perl $asm_src/$2 $1 $3.tmp
+	[[ $1 == "elf" ]] && cat <<-EOF >> $3.tmp
+	#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+	#endif
+	EOF
 	$MV $3.tmp $3
 }
 for abi in elf macosx; do


### PR DESCRIPTION
When generating ELF objects from assembly, gcc marks the GNU_STACK
program headers as RWX by default.  This is a security issue, so we
make sure it is marked only RW.

Signed-off-by: Anthony G. Basile blueness@gentoo.org
