### PR TITLE
Fixes for GitHub organisation rename

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,9 +7,9 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'libressl-portable' }}
+    if: ${{ github.repository_owner == 'libressl' }}
     env:
-      COVERITY_SCAN_PROJECT_NAME: 'libressl-portable/portable'
+      COVERITY_SCAN_PROJECT_NAME: 'libressl/portable'
       COVERITY_SCAN_BRANCH_PATTERN: '*'
       COVERITY_SCAN_NOTIFICATION_EMAIL: 'libressl-security@openbsd.org'
       COVERITY_SCAN_BUILD_COMMAND_PREPEND: "./autogen.sh && ./configure && make dist && tar zxf libressl-*.tar.gz && rm libressl-*.tar.gz && cd libressl-* && mkdir build-static && mkdir build-shared && cmake -GNinja -DBUILD_SHARED_LIBS=ON .."

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,12 +19,12 @@ with relevant portions of the C library, to a Git repository. This makes it
 easier to follow all of the relevant changes to the upstream project in a
 single place:
 
-	https://github.com/libressl-portable/openbsd
+	https://github.com/libressl/openbsd
 
 The portable bits of the project are largely maintained out-of-tree, and their
 history is also available from Git.
 
-	https://github.com/libressl-portable/portable
+	https://github.com/libressl/portable
 
 LibreSSL Portable Release Notes:
 
@@ -2602,7 +2602,7 @@ LibreSSL Portable Release Notes:
 	* Address POODLE attack by disabling SSLv3 by default
 
 	* Fix Eliptical Curve cipher selection bug
-	  (https://github.com/libressl-portable/portable/issues/35)
+	  (https://github.com/libressl/portable/issues/35)
 
 2.1.0 - First release from the OpenBSD 5.7 tree
 	* Added support for automatic ephemeral EC keys

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![LibreSSL image](https://www.libressl.org/images/libressl.jpg)
 ## Official portable version of [LibreSSL](https://www.libressl.org) ##
 
-[![Linux Build Status](https://github.com/libressl-portable/portable/actions/workflows/linux_test.yml/badge.svg)](https://github.com/libressl-portable/portable/actions/workflows/linux_test.yml)
-[![macOS Build Status](https://github.com/libressl-portable/portable/actions/workflows/macos_test.yml/badge.svg)](https://github.com/libressl-portable/portable/actions/workflows/macos_test.yml)
-[![Android_Build Status](https://github.com/libressl-portable/portable/actions/workflows/android_test.yml/badge.svg)](https://github.com/libressl-portable/portable/actions/workflows/android_test.yml)
-[![Cross_Build Status](https://github.com/libressl-portable/portable/actions/workflows/cross_test.yml/badge.svg)](https://github.com/libressl-portable/portable/actions/workflows/cross_test.yml)
+[![Linux Build Status](https://github.com/libressl/portable/actions/workflows/linux_test.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/linux_test.yml)
+[![macOS Build Status](https://github.com/libressl/portable/actions/workflows/macos_test.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/macos_test.yml)
+[![Android_Build Status](https://github.com/libressl/portable/actions/workflows/android_test.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/android_test.yml)
+[![Cross_Build Status](https://github.com/libressl/portable/actions/workflows/cross_test.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/cross_test.yml)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libressl.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:libressl)
-[![ASan Status](https://github.com/libressl-portable/portable/actions/workflows/linux_test_asan.yml/badge.svg)](https://github.com/libressl-portable/portable/actions/workflows/linux_test_asan.yml)
+[![ASan Status](https://github.com/libressl/portable/actions/workflows/linux_test_asan.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/linux_test_asan.yml)
 
 LibreSSL is a fork of [OpenSSL](https://www.openssl.org) 1.0.1g developed by the
 [OpenBSD](https://www.openbsd.org) project.  Our goal is to modernize the codebase,
@@ -52,11 +52,11 @@ OpenBSD mirror in directory
 although we suggest that you use a [mirror](https://www.openbsd.org/ftp.html).
 
 The LibreSSL portable build framework is also
-[mirrored](https://github.com/libressl-portable/portable) in Github.
+[mirrored](https://github.com/libressl/portable) on GitHub.
 
 Please report bugs either to the public libressl@openbsd.org mailing list,
-or to the github
-[issue tracker](https://github.com/libressl-portable/portable/issues)
+or to the GitHub
+[issue tracker](https://github.com/libressl/portable/issues)
 
 Severe vulnerabilities or bugs requiring coordination with OpenSSL can be
 sent to the core team at libressl-security@openbsd.org.

--- a/README.windows
+++ b/README.windows
@@ -46,7 +46,7 @@ problem.
 
 A script for generating ready-to-use .DLL and static .LIB files is included in
 the source repository at
-https://github.com/libressl-portable/portable/blob/master/dist-win.sh
+https://github.com/libressl/portable/blob/master/dist-win.sh
 
 This script uses mingw-w64 to build LibreSSL and then uses Visual Studio tools
 to generate compatible library import files ready-to-use with Visual

--- a/update.sh
+++ b/update.sh
@@ -7,7 +7,7 @@ openbsd_branch=`cat OPENBSD_BRANCH`
 echo "pulling upstream openbsd source"
 if [ ! -d openbsd ]; then
 	if [ -z "$LIBRESSL_GIT" ]; then
-		git clone https://github.com/libressl-portable/openbsd.git
+		git clone https://github.com/libressl/openbsd.git
 	else
 		git clone $LIBRESSL_GIT/openbsd
 	fi


### PR DESCRIPTION
This pull request changes all occurrences of 'https://github.com/libressl-portable/' to 'https://github.com/libressl/'
to adapt to the recent GitHub organisation rename. This also updates the coverity workflow to adapt to these changes.
