### PR TITLE
point OPENBSD_BRANCH to libressl-v3.7.0 for now

### DIFF
--- a/OPENBSD_BRANCH
+++ b/OPENBSD_BRANCH
@@ -1,1 +1,1 @@
-master
+libressl-v3.7.0

--- a/update.sh
+++ b/update.sh
@@ -14,8 +14,7 @@ if [ ! -d openbsd ]; then
 fi
 (cd openbsd
  git fetch
- git checkout $openbsd_branch
- git pull --rebase)
+ git checkout $openbsd_branch)
 
 # setup source paths
 CWD=`pwd`


### PR DESCRIPTION
re https://github.com/libressl/portable/issues/814#issuecomment-1423881715 temporarily point master to the 3.7.0  tag.