### PR TITLE
Fix build for MSVC

### DIFF
--- a/patches/crypto_namespace.h.patch
+++ b/patches/crypto_namespace.h.patch
@@ -1,13 +1,22 @@
---- crypto/hidden/crypto_namespace.h.orig	2023-02-28 00:41:43.212756628 -0600
-+++ crypto/hidden/crypto_namespace.h	2023-02-28 00:42:01.152756349 -0600
-@@ -18,6 +18,10 @@
- #ifndef _LIBCRYPTO_CRYPTO_NAMESPACE_H_
- #define _LIBCRYPTO_CRYPTO_NAMESPACE_H_
+--- openbsd/src/lib/libcrypto/hidden/crypto_namespace.h	2023-03-15 11:41:37.614024500 -0600
++++ crypto/hidden/crypto_namespace.h	2023-03-15 17:12:55.297157400 -0600
+@@ -24,6 +24,12 @@
+  * external calls use the latter name.
+  */
  
-+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__attribute__)
-+#define __attribute__(a)
-+#endif
-+
- /*
-  * If marked as 'used', then internal calls use the name with prefix "_lcry_"
-  * and we alias that to the normal name *and* the name with prefix "_libre_";
++#ifdef _MSC_VER
++# define LCRYPTO_UNUSED(x)
++# define LCRYPTO_USED(x)
++# define LCRYPTO_ALIAS1(pre, x)
++# define LCRYPTO_ALIAS(x)
++#else
+ #ifdef LIBRESSL_NAMESPACE
+ # define LCRYPTO_UNUSED(x)		typeof(x) x __attribute__((deprecated))
+ #ifdef LIBRESSL_CRYPTO_NAMESPACE
+@@ -40,5 +46,6 @@
+ # define LCRYPTO_ALIAS1(pre,x)
+ # define LCRYPTO_ALIAS(x)	asm("")
+ #endif
++#endif /* _MSC_VER */
+ 
+ #endif	/* _LIBCRYPTO_CRYPTO_NAMESPACE_H_ */

--- a/patches/libcrypto.hidden.patch
+++ b/patches/libcrypto.hidden.patch
@@ -1,0 +1,120 @@
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/hmac.h crypto/hidden/openssl/hmac.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/hmac.h	2023-03-15 11:41:37.632580800 -0600
++++ crypto/hidden/openssl/hmac.h	2023-03-15 16:49:29.144080400 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_HMAC_H_
+ #define _LIBCRYPTO_HMAC_H_
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/hmac.h>
++#else
+ #include_next <openssl/hmac.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(HMAC_CTX_new);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/pkcs12.h crypto/hidden/openssl/pkcs12.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/pkcs12.h	2023-03-15 11:41:37.648024900 -0600
++++ crypto/hidden/openssl/pkcs12.h	2023-03-15 17:15:36.015981800 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_PKCS12_H
+ #define _LIBCRYPTO_PKCS12_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/pkcs12.h>
++#else
+ #include_next <openssl/pkcs12.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(PKCS12_SAFEBAG_get0_attr);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/pkcs7.h crypto/hidden/openssl/pkcs7.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/pkcs7.h	2023-03-15 11:41:37.663599200 -0600
++++ crypto/hidden/openssl/pkcs7.h	2023-03-15 16:53:43.232866600 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_PKCS7_H
+ #define _LIBCRYPTO_PKCS7_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/pkcs7.h>
++#else
+ #include_next <openssl/pkcs7.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(PKCS7_ISSUER_AND_SERIAL_new);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/stack.h crypto/hidden/openssl/stack.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/stack.h	2023-03-15 11:41:37.680453800 -0600
++++ crypto/hidden/openssl/stack.h	2023-03-15 16:49:29.200142600 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_STACK_H
+ #define _LIBCRYPTO_STACK_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/stack.h>
++#else
+ #include_next <openssl/stack.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(sk_num);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/ui.h crypto/hidden/openssl/ui.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/ui.h	2023-03-15 11:41:37.696291800 -0600
++++ crypto/hidden/openssl/ui.h	2023-03-15 16:49:29.222310800 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_UI_H
+ #define _LIBCRYPTO_UI_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/ui.h>
++#else
+ #include_next <openssl/ui.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(UI_new);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/x509.h crypto/hidden/openssl/x509.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/x509.h	2023-03-15 11:41:37.713302600 -0600
++++ crypto/hidden/openssl/x509.h	2023-03-15 16:49:29.238904200 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_X509_H
+ #define _LIBCRYPTO_X509_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/x509.h>
++#else
+ #include_next <openssl/x509.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(X509_CRL_up_ref);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/x509v3.h crypto/hidden/openssl/x509v3.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/x509v3.h	2023-03-15 11:41:37.756379100 -0600
++++ crypto/hidden/openssl/x509v3.h	2023-03-15 16:49:29.264482800 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_X509V3_H
+ #define _LIBCRYPTO_X509V3_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/x509v3.h>
++#else
+ #include_next <openssl/x509v3.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(PROXY_POLICY_new);
+diff -u openbsd/src/lib/libcrypto/hidden/openssl/x509_vfy.h crypto/hidden/openssl/x509_vfy.h
+--- openbsd/src/lib/libcrypto/hidden/openssl/x509_vfy.h	2023-03-15 11:41:37.735995100 -0600
++++ crypto/hidden/openssl/x509_vfy.h	2023-03-15 16:49:29.300450300 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBCRYPTO_X509_VFY_H
+ #define _LIBCRYPTO_X509_VFY_H
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/x509_vfy.h>
++#else
+ #include_next <openssl/x509_vfy.h>
++#endif
+ #include "crypto_namespace.h"
+ 
+ LCRYPTO_USED(X509_STORE_set_depth);

--- a/patches/libssl.hidden.patch
+++ b/patches/libssl.hidden.patch
@@ -1,0 +1,15 @@
+diff -u openbsd/src/lib/libssl/hidden/openssl/ssl.h ssl/hidden/openssl/ssl.h
+--- openbsd/src/lib/libssl/hidden/openssl/ssl.h	2023-03-15 11:41:52.466146400 -0600
++++ ssl/hidden/openssl/ssl.h	2023-03-15 16:49:29.358377300 -0600
+@@ -18,7 +18,11 @@
+ #ifndef _LIBSSL_SSL_H_
+ #define _LIBSSL_SSL_H_
+ 
++#ifdef _MSC_VER
++#include <../include/openssl/ssl.h>
++#else
+ #include_next <openssl/ssl.h>
++#endif
+ #include "ssl_namespace.h"
+ 
+ LSSL_USED(BIO_f_ssl);

--- a/patches/opensslfeatures.h.patch
+++ b/patches/opensslfeatures.h.patch
@@ -1,0 +1,16 @@
+--- openbsd/src/lib/libcrypto/opensslfeatures.h	2023-03-15 11:41:47.301015100 -0600
++++ include/openssl/opensslfeatures.h	2023-03-15 18:27:57.740024800 -0600
+@@ -7,6 +7,13 @@
+ #define LIBRESSL_HAS_TLS1_3
+ #define LIBRESSL_HAS_DTLS1_2
+ 
++/*
++ * Used for compatibility with compilers lacking __attribute__
++ */
++#if defined(_MSC_VER) && !defined(__clang__) && !defined(__attribute__)
++#define __attribute__(a)
++#endif
++
+ #define OPENSSL_THREADS
+ 
+ #define OPENSSL_NO_BUF_FREELISTS

--- a/patches/ssl_namespace.h.patch
+++ b/patches/ssl_namespace.h.patch
@@ -1,13 +1,21 @@
---- ssl/hidden/ssl_namespace.h.orig	2023-02-28 00:42:20.928756042 -0600
-+++ ssl/hidden/ssl_namespace.h	2023-02-28 00:43:16.372755180 -0600
-@@ -18,6 +18,10 @@
- #ifndef _LIBSSL_SSL_NAMESPACE_H_
- #define _LIBSSL_SSL_NAMESPACE_H_
- 
-+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__attribute__)
-+#define __attribute__(a)
-+#endif
-+
- /*
-  * If marked as 'used', then internal calls use the name with prefix "_lssl_"
+--- openbsd/src/lib/libssl/hidden/ssl_namespace.h	2023-03-15 11:41:52.481641800 -0600
++++ ssl/hidden/ssl_namespace.h	2023-03-15 17:28:04.685309300 -0600
+@@ -23,6 +23,11 @@
   * and we alias that to the normal name.
+  */
+ 
++#ifdef _MSC_VER
++#define LSSL_UNUSED(x)
++#define LSSL_USED(x)
++#define LSSL_ALIAS(x)
++#else
+ #ifdef LIBRESSL_NAMESPACE
+ #define LSSL_UNUSED(x)		typeof(x) x __attribute__((deprecated))
+ #define LSSL_USED(x)		__attribute__((visibility("hidden")))	\
+@@ -33,5 +38,6 @@
+ #define LSSL_USED(x)
+ #define LSSL_ALIAS(x)		asm("")
+ #endif
++#endif /* _MSC_VER */
+ 
+ #endif	/* _LIBSSL_SSL_NAMESPACE_H_ */


### PR DESCRIPTION
We need the __attribute__ workaround still in a public header, or you can't use the result in any MSVC project anyway.
This also adds more #include_next workarounds for MSVC's lack of that feature.