### PR TITLE
Add CI workflow to run tests with ASM disabled

### DIFF
--- a/.github/workflows/linux_test_asan_noasm.yml
+++ b/.github/workflows/linux_test_asan_noasm.yml
@@ -1,0 +1,24 @@
+name: linux_ci_asan_noasm
+
+on: [push, pull_request]
+
+jobs:
+  build-native:
+    name: "${{ matrix.compiler }} - ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        compiler: ["clang"]
+    env:
+      CC: "${{ matrix.compiler }}"
+      ARCH: native
+      CFLAGS: "-ggdb -fsanitize=address"
+      LDFLAGS: "-fsanitize=address"
+      CTEST_OUTPUT_ON_FAILURE: 1
+      ENABLE_ASM: OFF
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@main
+      - name: "Run tests"
+        run: ./scripts/test

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,7 @@
 set -e
 
 unset CC
+ENABLE_ASM="${ENABLE_ASM:=ON}"
 
 if type apt-get >/dev/null
 then
@@ -27,21 +28,21 @@ if [ "x$ARCH" = "xnative" ]; then
 
 	# test cmake and ninja
 	if [ `uname` = "Darwin" ]; then
-		cmake ..
+		cmake -DENABLE_ASM=${ENABLE_ASM} ..
 		make -j 4
 		make test
 
 		cd ../build-shared
-		cmake -DBUILD_SHARED_LIBS=ON ..
+		cmake -DBUILD_SHARED_LIBS=ON -DENABLE_ASM=${ENABLE_ASM} ..
 		make -j 4
 		make test
 	else
-		cmake -GNinja ..
+		cmake -GNinja -DENABLE_ASM=${ENABLE_ASM} ..
 		ninja -j 4
 		ninja test
 
 		cd ../build-shared
-		cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
+		cmake -GNinja -DBUILD_SHARED_LIBS=ON -DENABLE_ASM=${ENABLE_ASM} ..
 		ninja -j 4
 		ninja test
 	fi
@@ -61,14 +62,14 @@ elif [ "x$ARCH" = "xmingw32" -o "x$ARCH" = "xmingw64" ]; then
 	 rm -fr build-static
 	 mkdir build-static
 	 cd build-static
-	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake ..
+	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake -DENABLE_ASM=${ENABLE_ASM} ..
 	 ninja -j 4
 	)
 	(
 	 rm -fr build-shared
 	 mkdir build-shared
 	 cd build-shared
-	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake -DBUILD_SHARED_LIBS=ON ..
+	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake -DBUILD_SHARED_LIBS=ON -DENABLE_ASM=${ENABLE_ASM} ..
 	 ninja -j 4
 	)
 
@@ -140,7 +141,8 @@ elif [ "x$ARCH" = "xandroid" ]; then
 		 cmake -GNinja -DCMAKE_MAKE_PROGRAM=ninja \
 		 -DANDROID_NDK=$ANDROID_NDK_HOME \
 		 -DCMAKE_TOOLCHAIN_FILE=$TC_FILE \
-		 -DANDROID_ABI=$ABI -DANDROID_NATIVE_API_LEVEL=$NAL ..
+		 -DANDROID_ABI=$ABI -DANDROID_NATIVE_API_LEVEL=$NAL \
+		 -DENABLE_ASM=${ENABLE_ASM} ..
 
 		 ninja -j 4
 


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to run tests with ENABLE_ASM=off and ASAN enabled.
