### PR TITLE
Fix urllib3 CN without SAN tests for LibreSSL 3.7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,13 @@ history is also available from Git.
 
 LibreSSL Portable Release Notes:
 
+
+3.7.3 - Stable release
+
+	* Bug fix
+	  - Hostflags in the verify parameters would not propagate from an
+	    SSL_CTX to newly created SSL.
+
 3.7.2 - Stable release
 
 	* Portable changes

--- a/patches/x509_vpm.c.patch
+++ b/patches/x509_vpm.c.patch
@@ -1,0 +1,21 @@
+--- crypto/x509/x509_vpm.c.orig	Thu May 25 09:08:38 2023
++++ crypto/x509/x509_vpm.c	Thu May 25 09:08:48 2023
+@@ -330,7 +330,9 @@ X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest, con
+ 			return 0;
+ 	}
+ 
+-	/* Copy the host flags if and only if we're copying the host list */
++	if (test_x509_verify_param_copy_id(hostflags, 0))
++		dest->id->hostflags = id->hostflags;
++
+ 	if (test_x509_verify_param_copy_id(hosts, NULL)) {
+ 		if (dest->id->hosts) {
+ 			string_stack_free(dest->id->hosts);
+@@ -341,7 +343,6 @@ X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest, con
+ 			    sk_deep_copy(id->hosts, strdup, str_free);
+ 			if (dest->id->hosts == NULL)
+ 				return 0;
+-			dest->id->hostflags = id->hostflags;
+ 		}
+ 	}
+ 


### PR DESCRIPTION
This is a port of a patch by Christian Heimes and fixes an issue flagged by Quentin Pradet: https://bugs.python.org/issue43522