### PR TITLE
reenable ssltest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -659,12 +659,12 @@ add_test(ssl_versions ssl_versions)
 # ssltest
 add_executable(ssltest ssltest.c)
 target_link_libraries(ssltest ${OPENSSL_TEST_LIBS})
-#if(NOT MSVC)
-#	add_test(NAME ssltest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.sh)
-#else()
-#	add_test(NAME ssltest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.bat $<TARGET_FILE:ssltest> $<TARGET_FILE:openssl>)
-#endif()
-#set_tests_properties(ssltest PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
+if(NOT MSVC)
+	add_test(NAME ssltest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.sh)
+else()
+	add_test(NAME ssltest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.bat $<TARGET_FILE:ssltest> $<TARGET_FILE:openssl>)
+endif()
+set_tests_properties(ssltest PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
 
 # string_table
 add_executable(string_table string_table.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -678,7 +678,7 @@ check_PROGRAMS += ssl_versions
 ssl_versions_SOURCES = ssl_versions.c
 
 # ssltest
-#TESTS += ssltest.sh
+TESTS += ssltest.sh
 check_PROGRAMS += ssltest
 ssltest_SOURCES = ssltest.c
 EXTRA_DIST += ssltest.sh ssltest.bat


### PR DESCRIPTION
failure in ASAN was unrelated to tls 1.0/1.1 changes