### PR TITLE
generate opensslconf.h in build dir for cmake

### DIFF
--- a/apps/nc/CMakeLists.txt
+++ b/apps/nc/CMakeLists.txt
@@ -36,8 +36,14 @@ else()
 endif()
 
 add_executable(nc ${NC_SRC})
-target_include_directories(nc PUBLIC ../../include)
-target_include_directories(nc PRIVATE . ./compat ../../include/compat)
+target_include_directories(nc
+	PRIVATE
+		.
+		./compat
+		../../include/compat
+	PUBLIC
+		../../include
+		${CMAKE_BINARY_DIR}/include)
 target_link_libraries(nc ${LIBTLS_LIBS})
 
 if(ENABLE_NC)

--- a/apps/ocspcheck/CMakeLists.txt
+++ b/apps/ocspcheck/CMakeLists.txt
@@ -8,9 +8,9 @@ set(
 
 check_function_exists(memmem HAVE_MEMMEM)
 if(HAVE_MEMMEM)
-        add_definitions(-DHAVE_MEMMEM)
+	add_definitions(-DHAVE_MEMMEM)
 else()
-        set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/memmem.c)
+	set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/memmem.c)
 endif()
 
 if(NOT "${OPENSSLDIR}" STREQUAL "")
@@ -20,8 +20,12 @@ else()
 endif()
 
 add_executable(ocspcheck ${OCSPCHECK_SRC})
-target_include_directories(ocspcheck PUBLIC ../../include)
-target_include_directories(ocspcheck PRIVATE . ./compat ../../include/compat)
+target_include_directories(ocspcheck
+	PRIVATE
+		../../include/compat
+	PUBLIC
+		../../include
+		${CMAKE_BINARY_DIR}/include)
 target_link_libraries(ocspcheck tls ${OPENSSL_LIBS})
 
 if(ENABLE_LIBRESSL_INSTALL)

--- a/apps/openssl/CMakeLists.txt
+++ b/apps/openssl/CMakeLists.txt
@@ -61,15 +61,20 @@ if(WIN32)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-        check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
-        if(NOT HAVE_CLOCK_GETTIME)
-                set(OPENSSL_SRC ${OPENSSL_SRC} compat/clock_gettime_osx.c)
-        endif()
+	check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+	if(NOT HAVE_CLOCK_GETTIME)
+			set(OPENSSL_SRC ${OPENSSL_SRC} compat/clock_gettime_osx.c)
+	endif()
 endif()
 
 add_executable(openssl ${OPENSSL_SRC})
-target_include_directories(openssl PUBLIC ../../include)
-target_include_directories(openssl PRIVATE . ../../include/compat)
+target_include_directories(openssl
+	PRIVATE
+		.
+		../../include/compat
+	PUBLIC
+		../../include
+		${CMAKE_BINARY_DIR}/include)
 target_link_libraries(openssl ${OPENSSL_LIBS})
 
 if(ENABLE_LIBRESSL_INSTALL)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -997,7 +997,8 @@ target_include_directories(crypto_obj
 		x509
 		../include/compat
 	PUBLIC
-		../include)
+		../include
+		${CMAKE_BINARY_DIR}/include)
 
 if(HOST_AARCH64)
 	target_include_directories(crypto_obj PRIVATE bn/arch/aarch64/)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,7 +4,10 @@ if(ENABLE_LIBRESSL_INSTALL)
 	        PATTERN "CMakeLists.txt" EXCLUDE
 	        PATTERN "compat" EXCLUDE
 	        PATTERN "pqueue.h" EXCLUDE
-	        PATTERN "Makefile*" EXCLUDE)
+	        PATTERN "Makefile*" EXCLUDE
+	        PATTERN "arch" EXCLUDE)
+	install(FILES ${CMAKE_BINARY_DIR}/include/openssl/opensslconf.h
+	        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/openssl")
 endif(ENABLE_LIBRESSL_INSTALL)
 
 if(HOST_AARCH64)
@@ -28,4 +31,4 @@ elseif(HOST_SPARC64)
 elseif(HOST_X86_64)
 	file(READ arch/amd64/opensslconf.h OPENSSLCONF)
 endif()
-file(WRITE openssl/opensslconf.h "${OPENSSLCONF}")
+file(WRITE ${CMAKE_BINARY_DIR}/include/openssl/opensslconf.h "${OPENSSLCONF}")

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -69,7 +69,8 @@ target_include_directories(ssl_obj
 		../crypto/bio
 		../include/compat
 	PUBLIC
-		../include)
+		../include
+		${CMAKE_BINARY_DIR}/include)
 
 add_library(bs_obj OBJECT ${BS_SRC})
 target_include_directories(bs_obj

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(
 	../apps/openssl
 	../apps/openssl/compat
 	../include
+	${CMAKE_BINARY_DIR}/include
 	../include/compat
 )
 

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -45,7 +45,8 @@ target_include_directories(tls_obj
 		.
 		../include/compat
 	PUBLIC
-		../include)
+		../include
+		${CMAKE_BINARY_DIR}/include)
 
 add_library(tls $<TARGET_OBJECTS:tls_obj> $<TARGET_OBJECTS:ssl_obj>
 	$<TARGET_OBJECTS:crypto_obj> empty.c)


### PR DESCRIPTION
This fixes #871 for CMake so we are not modifying the source directory unnecessarily. This also stops installing all of the arch-specific includes.