### PR TITLE
Fix cross compile macos

### DIFF
--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -6,13 +6,12 @@ jobs:
   build-native:
     strategy:
       matrix:
-        os: [macos-12, macos-11]
-        compiler: [clang, gcc]
+        os: [macos-13, macos-12]
+        arch: [arm64, x86_64]
     runs-on: ${{ matrix.os }}
     continue-on-error: false
     env:
-      CC: ${{ matrix.compiler }}
-      ARCH: native
+      ARCH: ${{ matrix.arch }}
     name: ${{ matrix.compiler }} - ${{ matrix.os }}
     steps:
     - name: Install packages for macos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,15 @@ if(HAVE_NETINET_IP_H)
 	add_definitions(-DHAVE_NETINET_IP_H)
 endif()
 
+# This isn't ready for universal binaries yet, since we do conditional
+# compilation based on the architecture, but this makes cross compiling for a
+# single architecture work on macOS at least.
+#
+# Don't set CMAKE_OSX_ARCHITECTURES to more than a single value for now.
+if(APPLE)
+	set(CMAKE_SYSTEM_PROCESSOR "${CMAKE_OSX_ARCHITECTURES}")
+endif()
+
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(aarch64|arm64)")
 	set(HOST_AARCH64 true)
 elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")

--- a/scripts/test
+++ b/scripts/test
@@ -10,46 +10,77 @@ if type apt-get >/dev/null 2>&1; then
 	sudo apt-get install -y cmake ninja-build
 fi
 
+# generate source tree
 ./autogen.sh
 
-if [ "x$ARCH" = "xnative" ]; then
+if [ "$ARCH" = "" ]; then
+	ARCH=`uname -m`
+fi
+
+# test macOS
+if [ `uname` = "Darwin" ]; then
 	# test autotools
 	./configure
-	make -j 4 distcheck
 
 	# make distribution
-	make dist
+	make -j 4 distcheck
+
+	# test cmake
 	tar zxvf libressl-*.tar.gz
 	cd libressl-*
-	mkdir build-static
-	mkdir build-shared
 
-	cd build-static
+	(
+		mkdir build-static
+		cd build-static
+		cmake -DCMAKE_OSX_ARCHITECTURES=$ARCH ..
+		make -j 4
+		if [ "$ARCH" = "x86_64" ]; then
+			make test
+		fi
+	)
+
+	(
+		mkdir build-shared
+		cd build-shared
+		cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=$ARCH ..
+		make -j 4
+		if [ "$ARCH" = "x86_64" ]; then
+			make test
+		fi
+	)
+
+# assuming Linux below
+elif [ "$ARCH" = "native" ]; then
+	# test autotools
+	./configure
+
+	# make distribution
+	make -j 4 distcheck
+
+	tar zxvf libressl-*.tar.gz
+	cd libressl-*
+
 
 	# test cmake and ninja
-	if [ `uname` = "Darwin" ]; then
-		cmake -DENABLE_ASM=${ENABLE_ASM} ..
-		make -j 4
-		make test
-
-		cd ../build-shared
-		cmake -DBUILD_SHARED_LIBS=ON -DENABLE_ASM=${ENABLE_ASM} ..
-		make -j 4
-		make test
-	else
+	(
+		mkdir build-static
+		cd build-static
 		cmake -GNinja -DENABLE_ASM=${ENABLE_ASM} ..
-		ninja -j 4
+		ninja
 		ninja test
+	)
 
-		cd ../build-shared
+	(
+		mkdir build-shared
+		cd build-shared
 		cmake -GNinja -DBUILD_SHARED_LIBS=ON -DENABLE_ASM=${ENABLE_ASM} ..
-		ninja -j 4
+		ninja
 		ninja test
-	fi
+	)
 
-elif [ "x$ARCH" = "xmingw32" -o "x$ARCH" = "xmingw64" ]; then
+elif [ "$ARCH" = "mingw32" -o "$ARCH" = "mingw64" ]; then
 	CPU=i686
-	if [ "x$ARCH" = "xmingw64" ]; then
+	if [ "$ARCH" = "mingw64" ]; then
 		CPU=x86_64
 	fi
 
@@ -75,10 +106,10 @@ elif [ "x$ARCH" = "xmingw32" -o "x$ARCH" = "xmingw64" ]; then
 	 ninja -j 4
 	)
 
-elif [ "x$ARCH" = "xarm32" -o "x$ARCH" = "xarm64" ]; then
+elif [ "$ARCH" = "arm32" -o "$ARCH" = "arm64" ]; then
 	sudo apt-get install -y qemu-user-static binfmt-support
 
-	if [ "x$ARCH" = "xarm32" ]; then
+	if [ "$ARCH" = "arm32" ]; then
 		sudo apt-get install -y g++-arm-linux-gnueabihf
 		sudo ln -sf /usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.3 /lib/
 		./configure --host=arm-linux-gnueabihf
@@ -92,10 +123,10 @@ elif [ "x$ARCH" = "xarm32" -o "x$ARCH" = "xarm64" ]; then
 
 	file apps/openssl/.libs/openssl
 
-elif [ "x$ARCH" = "xmips32" -o "x$ARCH" = "xmips64" ]; then
+elif [ "$ARCH" = "mips32" -o "$ARCH" = "mips64" ]; then
 	sudo apt-get install -y qemu-user-static binfmt-support
 
-	if [ "x$ARCH" = "xmips32" ]; then
+	if [ "$ARCH" = "mips32" ]; then
 		sudo apt-get install -y g++-mips-linux-gnu
 		sudo ln -sf /usr/mipsel-linux-gnu/lib/ld.so.1 /lib/
 		./configure --host=mipsel-linux-gnu
@@ -109,7 +140,7 @@ elif [ "x$ARCH" = "xmips32" -o "x$ARCH" = "xmips64" ]; then
 
 	file apps/openssl/.libs/openssl
 
-elif [ "x$ARCH" = "xandroid" ]; then
+elif [ "$ARCH" = "android" ]; then
 	export TC_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake
 
 	# set target API level and architecture


### PR DESCRIPTION
Fixes #876 by adding the ability to specify one architecture at a time for CMAKE_OSX_ARCHITECTURES at least. Also add Ventura and Apple silicon compile checks to test matrix, removing Big Sur and gcc, which I think has been clang anyway for a while.