### PR TITLE
only link libtls statically to libssl/libcrypto when building standalone

### DIFF
--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -20,10 +20,17 @@ libtls_la_objects.mk: Makefile
 	  > libtls_la_objects.mk
 
 libtls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined -export-symbols $(top_srcdir)/tls/tls.sym
+
+if ENABLE_LIBTLS_ONLY
 libtls_la_LIBADD = $(libcrypto_la_objects)
+libtls_la_LIBADD += $(libssl_la_objects)
+else
+libtls_la_LIBADD = $(abs_top_builddir)/crypto/libcrypto.la
+libtls_la_LIBADD += $(abs_top_builddir)/ssl/libssl.la
+endif
+
 libtls_la_LIBADD += $(libcompat_la_objects)
 libtls_la_LIBADD += $(libcompatnoopt_la_objects)
-libtls_la_LIBADD += $(libssl_la_objects)
 libtls_la_LIBADD += $(PLATFORM_LDADD)
 
 libtls_la_CPPFLAGS = $(AM_CPPFLAGS)


### PR DESCRIPTION
This solves a problem where a program, such as opensmtpd, may need to modify the state of libcrypto, but have a surprising effect when this does not affect the crypto code that libtls is using, since it is a standalone copy.

This changes build behavior introduced in 2020 back to dynamically linking libtls to libssl/libcrypto by default, but the existing --enable-libtls-only flag will still build a fully self-contained library. However, note that linking libcrypto/libssl to a binary using a standalone libtls will cause libtls to always use its internal crypto/tls code, instead of that from the external libraries.