### PR TITLE
move attribute shims

### DIFF
--- a/include/compat/stdint.h
+++ b/include/compat/stdint.h
@@ -16,4 +16,16 @@
 #include <limits.h>
 #endif
 
+#if !defined(HAVE_ATTRIBUTE__BOUNDED__) && !defined(__bounded__)
+# define __bounded__(x, y, z)
+#endif
+
+#if !defined(HAVE_ATTRIBUTE__DEAD) && !defined(__dead)
+#ifdef _MSC_VER
+#define __dead      __declspec(noreturn)
+#else
+#define __dead      __attribute__((__noreturn__))
+#endif
+#endif
+
 #endif

--- a/include/compat/sys/types.h
+++ b/include/compat/sys/types.h
@@ -45,18 +45,6 @@ typedef SSIZE_T ssize_t;
 
 #endif
 
-#if !defined(HAVE_ATTRIBUTE__BOUNDED__) && !defined(__bounded__)
-# define __bounded__(x, y, z)
-#endif
-
-#if !defined(HAVE_ATTRIBUTE__DEAD) && !defined(__dead)
-#ifdef _MSC_VER
-#define __dead      __declspec(noreturn)
-#else
-#define __dead      __attribute__((__noreturn__))
-#endif
-#endif
-
 #ifdef _WIN32
 #define __warn_references(sym,msg)
 #else


### PR DESCRIPTION
There's not a great place for these, but since they are internal, we can just move them to the most common header.