### PR TITLE
change the trigger for running fuzzer tests

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,10 @@
 name: CIFuzz
-on: [pull_request]
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 * * *"
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since fuzzers benefit more from being run regularly on the openbsd tree, and they take a long time, does it make more sense that the trigger is a cron like the Coverity job? They sometimes don't work in branches anyway, since the fuzz builds rely on external code being updated to match the master branch.