### PR TITLE
set default build type to 'Release'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.20.0)
+cmake_minimum_required (VERSION 3.16.4)
 if(MSVC)
 	cmake_policy(SET CMP0091 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
+cmake_minimum_required (VERSION 3.20.0)
 if(MSVC)
-	cmake_minimum_required (VERSION 3.16.4)
 	cmake_policy(SET CMP0091 NEW)
-else()
-	cmake_minimum_required (VERSION 3.0)
 endif()
 
 project (LibreSSL C ASM)
@@ -51,6 +49,17 @@ if(NOT LIBRESSL_SKIP_INSTALL)
 	set( ENABLE_LIBRESSL_INSTALL ON )
 endif(NOT LIBRESSL_SKIP_INSTALL)
 
+# Set a default build type if none was specified
+set(default_build_type "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+	  STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 set(BUILD_NC true)
 


### PR DESCRIPTION
A variation from https://www.kitware.com/cmake-and-the-default-build-type/ to default to enabling optimizations if no build type is specified.