### PR TITLE
MSVC: Fixes from vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,8 @@ if(MSVC)
 			"C4706" # assignment within conditional expression
 			"C4996" # The POSIX name for this item is deprecated.
 				# Instead, use the ISO C and C++ conformant name
+			"C5045" # Compiler will insert Spectre mitigation for memory
+				# load if /Qspectre switch specified
 		)
 	elseif(CMAKE_C_COMPILER_ID MATCHES "Intel")
 		add_definitions(-D_CRT_SUPPRESS_RESTRICT)
@@ -186,6 +188,10 @@ if(MSVC)
 		${MSVC_DISABLED_WARNINGS_LIST})
 	string(REGEX REPLACE "[/-]W[1234][ ]?" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -MP -W4 ${MSVC_DISABLED_WARNINGS_STR}")
+	if(MSVC_VERSION GREATER_EQUAL 1912)
+		message(STATUS "Enabling spectre mitigation")
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Qspectre")
+	endif()
 endif()
 
 check_function_exists(asprintf HAVE_ASPRINTF)

--- a/apps/ocspcheck/CMakeLists.txt
+++ b/apps/ocspcheck/CMakeLists.txt
@@ -1,5 +1,3 @@
-if(NOT MSVC)
-
 set(
 	OCSPCHECK_SRC
 	http.c
@@ -33,5 +31,3 @@ if(ENABLE_LIBRESSL_INSTALL)
 	install(FILES ocspcheck.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
 
 endif(ENABLE_LIBRESSL_INSTALL)
-
-endif()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -778,6 +778,8 @@ endif()
 if(NOT HAVE_GETOPT)
 	set(CRYPTO_SRC ${CRYPTO_SRC} compat/getopt_long.c)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} getopt)
+	set(EXTRA_EXPORT ${EXTRA_EXPORT} optarg)
+	set(EXTRA_EXPORT ${EXTRA_EXPORT} optind)
 endif()
 
 if(NOT HAVE_GETPAGESIZE)

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -23,6 +23,7 @@ ssize_t pwrite(int d, const void *buf, size_t nbytes, off_t offset);
 #include <io.h>
 #include <process.h>
 
+#define STDIN_FILENO    0
 #define STDOUT_FILENO   1
 #define STDERR_FILENO   2
 
@@ -65,7 +66,7 @@ int getentropy(void *buf, size_t buflen);
 #endif
 
 #ifndef HAVE_GETOPT
-#include <getopt.h>
+#include "getopt.h"
 #endif
 
 #ifndef HAVE_GETPAGESIZE

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -22,6 +22,8 @@ if(WIN32)
 		compat/pread.c
 		compat/pwrite.c
 	)
+
+	set(LIBTLS_EXTRA_EXPORT ${LIBTLS_EXTRA_EXPORT} ftruncate)
 endif()
 
 if(NOT "${OPENSSLDIR}" STREQUAL "")


### PR DESCRIPTION
MSVC currently has two patches for its LibreSSL port.

[The first patch](https://github.com/microsoft/vcpkg/blob/master/ports/libressl/0001-enable-ocspcheck-on-msvc.patch) enables building `ocspcheck` with MSVC. This requires:
- `getopt`, which is already included in `libcrypto`. Adding `optarg` and `optind` to the DLL exports is necessary.
- `ftruncate`, which is already included in `libtls`. Adding it to the DLL exports is necessary.
- Defining `STDIN_FILENO` in the `unistd.h` compat header.

[The second patch](https://github.com/microsoft/vcpkg/blob/master/ports/libressl/0002-suppress-msvc-warnings.patch) handles the [Spectre vulnerability mitigation](https://learn.microsoft.com/en-us/cpp/build/reference/qspectre?view=msvc-170). The warning [C5045](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5045?view=msvc-170) triggers whether `/Qspectre` is used or not and warns about code that may be affected by this vulnerability.