### PR TITLE
Cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,8 +473,8 @@ if(ENABLE_LIBRESSL_INSTALL)
   	INSTALL_DESTINATION "${LIBRESSL_INSTALL_CMAKEDIR}"
 	)
 	install(FILES
-		"${CMAKE_BINARY_DIR}/install-config/LibreSSLConfig.cmake"
-		"${CMAKE_BINARY_DIR}/LibreSSLConfigVersion.cmake"
+		"${CMAKE_CURRENT_BINARY_DIR}/install-config/LibreSSLConfig.cmake"
+		"${CMAKE_CURRENT_BINARY_DIR}/LibreSSLConfigVersion.cmake"
 		DESTINATION "${LIBRESSL_INSTALL_CMAKEDIR}"
 	)
 endif()

--- a/LibreSSLConfig.cmake.in
+++ b/LibreSSLConfig.cmake.in
@@ -6,16 +6,19 @@ set_and_check(LIBRESSL_INCLUDE_DIR @PACKAGE_INCLUDE_DIRECTORY@)
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/LibreSSL-Crypto.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/LibreSSL-Crypto.cmake")
   set(LIBRESSL_CRYPTO_LIBRARY LibreSSL::Crypto)
+  set(LibreSSL_Crypto_FOUND TRUE)
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/LibreSSL-SSL.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/LibreSSL-SSL.cmake")
   set(LIBRESSL_SSL_LIBRARY LibreSSL::SSL)
+  set(LibreSSL_SSL_FOUND TRUE)
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/LibreSSL-TLS.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/LibreSSL-TLS.cmake")
   set(LIBRESSL_TLS_LIBRARY LibreSSL::TLS)
+  set(LibreSSL_TLS_FOUND TRUE)
 endif()
 
 set(LIBRESSL_LIBRARIES
@@ -24,10 +27,10 @@ set(LIBRESSL_LIBRARIES
   ${LIBRESSL_TLS_LIBRARY}
 )
 
-check_required_components(
-  Crypto
-  SSL
-  TLS
-)
+check_required_components(LibreSSL)
 
-set(LIBRESSL_FOUND TRUE)
+if(DEFINED LibreSSL_FOUND)
+	set(LIBRESSL_FOUND ${LibreSSL_FOUND})
+else()
+	set(LIBRESSL_FOUND TRUE)
+endif()


### PR DESCRIPTION
`check_required_components` does not take a list of components; it takes the package name and determines if a component is available by checking the `<package>_<component>_FOUND` variable.  Without this change, `find_package(LibreSSL REQUIRED COMPONENTS Invalid)` would succeed despite that component not existing.

This change also makes `LIBRESSL_FOUND` mirror the `LibreSSL_FOUND` variable that cmake uses internally to check if the package exists, and changes the `install` source paths of the cmake files to match the ones they were configured with.