### PR TITLE
package getopt compat files

### DIFF
--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -36,6 +36,7 @@ EXTRA_DIST += empty.c
 
 # needed for a CMake target
 EXTRA_DIST += compat/strcasecmp.c
+EXTRA_DIST += compat/getopt_long.c
 
 BUILT_SOURCES = crypto_portable.sym
 CLEANFILES = crypto_portable.sym

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,6 +10,7 @@ noinst_HEADERS += compat/dirent_msvc.h
 noinst_HEADERS += compat/endian.h
 noinst_HEADERS += compat/err.h
 noinst_HEADERS += compat/fcntl.h
+noinst_HEADERS += compat/getopt.h
 noinst_HEADERS += compat/limits.h
 noinst_HEADERS += compat/netdb.h
 noinst_HEADERS += compat/poll.h


### PR DESCRIPTION
This fixes #908 by including getopt compat files with the release package.