### PR TITLE
enable system arc4random on FreeBSD 12+

### DIFF
--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -61,9 +61,15 @@ char buf[1]; getentropy(buf, 1);
 	*freebsd*)
 		HOST_OS=freebsd
 		HOST_ABI=elf
-		# fork detection missing, weak seed on failure
-		# https://svnweb.freebsd.org/base/head/lib/libc/gen/arc4random.c?revision=268642&view=markup
-		USE_BUILTIN_ARC4RANDOM=yes
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <sys/param.h>
+#if __FreeBSD_version < 1200000
+        undefined
+#endif
+                       ]], [[]])],
+                       [ USE_BUILTIN_ARC4RANDOM=no ],
+                       [ USE_BUILTIN_ARC4RANDOM=yes ]
+		)
 		AC_SUBST([PROG_LDADD], ['-lthr'])
 		;;
 	*hpux*)


### PR DESCRIPTION
Fixes #911 