### PR TITLE
delete unused `savsig` variable on Windows

### DIFF
--- a/crypto/compat/ui_openssl_win.c
+++ b/crypto/compat/ui_openssl_win.c
@@ -130,9 +130,6 @@
 #define NX509_SIG 32
 #endif
 
-/* Define globals.  They are protected by a lock */
-static void (*savsig[NX509_SIG])(int );
-
 DWORD console_mode;
 static FILE *tty_in, *tty_out;
 static int is_a_tty;


### PR DESCRIPTION
Fixes:
```
./libressl/crypto/ui/ui_openssl_win.c:134:15: warning: unused variable 'savsig' [-Wunused-variable]
  134 | static void (*savsig[NX509_SIG])(int );
      |               ^~~~~~
1 warning generated.
```

Follow-up to dd1d96f643b01a5edbe7e0db8399f3c88f5f0c8b

Fixes #925
