### PR TITLE
slim `tls-static` library (used in tests)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,7 @@ set(LIBTLS_LIBS tls ${PLATFORM_LIBS})
 # libraries for regression test
 if(BUILD_SHARED_LIBS)
 	set(OPENSSL_TEST_LIBS ssl-static crypto-static ${PLATFORM_LIBS})
-	set(LIBTLS_TEST_LIBS tls-static ${PLATFORM_LIBS})
+	set(LIBTLS_TEST_LIBS tls-static ${OPENSSL_TEST_LIBS})
 else()
 	set(OPENSSL_TEST_LIBS ssl crypto ${PLATFORM_LIBS})
 	set(LIBTLS_TEST_LIBS tls ${PLATFORM_LIBS})

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -101,8 +101,7 @@ endif(ENABLE_LIBRESSL_INSTALL)
 
 # build static library for regression test
 if(BUILD_SHARED_LIBS)
-	add_library(tls-static STATIC $<TARGET_OBJECTS:tls_obj>
-		$<TARGET_OBJECTS:ssl_obj> $<TARGET_OBJECTS:crypto_obj>)
-	target_link_libraries(tls-static ${PLATFORM_LIBS})
+	add_library(tls-static STATIC $<TARGET_OBJECTS:tls_obj>)
+	target_link_libraries(tls-static ${OPENSSL_TEST_LIBS})
 endif()
 


### PR DESCRIPTION
Instead of including a full copy of libcrypto and libssl in libtls-static, link existing libcrytpo-static and libssl-static to the test targets.

This wasn't causing any issue, just unnecessarily duplicating a lot of objects.