### PR TITLE
ci: add --verbose flag to rust-openssl cargo test

### DIFF
--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -32,4 +32,4 @@ jobs:
           OPENSSL_DIR=${HOME}/opt
           LD_LIBRARY_PATH=${HOME}/opt/lib
           patch -p1 < ../.github/rust-openssl.patch
-          cargo test
+          cargo test --verbose


### PR DESCRIPTION
Add `--verbose` flag to the `cargo test` command in the `rust-openssl` workflow to allow for more visibility.

Requested in https://github.com/libressl/portable/pull/944#discussion_r1389316062