### PR TITLE
Fix rust-openssl regress

### DIFF
--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -29,7 +29,6 @@ jobs:
       - name: "Run rust-openssl tests"
         run: |
           cd rust-openssl
-          OPENSSL_DIR=${HOME}/opt
-          LD_LIBRARY_PATH=${HOME}/opt/lib
           patch -p1 < ../.github/rust-openssl.patch
+          export OPENSSL_DIR=${HOME}/opt LD_LIBRARY_PATH=${HOME}/opt/lib
           cargo test --verbose


### PR DESCRIPTION
Change around the order slightly. It seems more logical to apply the patch first, then export the env.