### PR TITLE
disable periodic builds of broken CI workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,10 +1,5 @@
 name: CIFuzz
 
-on:
-  workflow_dispatch:
-  schedule:
-  - cron: "0 0 * * *"
-
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,8 @@
 name: CIFuzz
 
+on:
+  workflow_dispatch:
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/solaris_test.yml
+++ b/.github/workflows/solaris_test.yml
@@ -1,5 +1,8 @@
 name: solaris_ci
 
+on:
+  workflow_dispatch:
+
 jobs:
   build-native:
     strategy:

--- a/.github/workflows/solaris_test.yml
+++ b/.github/workflows/solaris_test.yml
@@ -1,10 +1,5 @@
 name: solaris_ci
 
-on:
-  workflow_dispatch:
-  schedule:
-  - cron: "0 0 * * *"
-
 jobs:
   build-native:
     strategy:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Linux Build Status](https://github.com/libressl/portable/actions/workflows/linux.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/linux.yml)
 [![macOS Build Status](https://github.com/libressl/portable/actions/workflows/macos.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/macos.yml)
 [![Android Build Status](https://github.com/libressl/portable/actions/workflows/android.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/android.yml)
-[![Solaris Build Status](https://github.com/libressl/portable/actions/workflows/solaris_test.yml/badge.svg)](https://github.com/libressl/portable/actions/workflows/solaris_test.yml)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libressl.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:libressl)
 
 LibreSSL is a fork of [OpenSSL](https://www.openssl.org) 1.0.1g developed by the


### PR DESCRIPTION
Neither of these has built in over a month.

Solaris looks to be an upstream timeout issue (seems the hack it uses may not work anymore).
https://github.com/libressl/portable/actions/runs/6999379749

Not sure if cifuzz is really needed either, since we're still being tested through clusterfuzz actively.
https://github.com/libressl/portable/actions/runs/7012733325