### PR TITLE
windows: always upload build artifacts, even in case of failure

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -40,6 +40,7 @@ jobs:
         if: ${{ matrix.arch != 'ARM64' }}
         run: ctest --test-dir build -C Release --output-on-failure
       - uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: windows-build-results-${{ matrix.os }}-${{ matrix.arch }}
           path: build


### PR DESCRIPTION
during windows release creating, I've found useful to have build artifacts always uploaded