### PR TITLE
cmake: auto-detect `strtonum`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,11 @@ if(HAVE_STRSEP)
 	add_definitions(-DHAVE_STRSEP)
 endif()
 
+check_function_exists(strtonum HAVE_STRTONUM)
+if(HAVE_STRTONUM)
+	add_definitions(-DHAVE_STRTONUM)
+endif()
+
 check_function_exists(timegm HAVE_TIMEGM)
 if(HAVE_TIMEGM)
 	add_definitions(-DHAVE_TIMEGM)


### PR DESCRIPTION
Notice that just like in autotools, this detection also doesn't take
into account the targeted OS version. Meaning it detects `strtonum` even
if targeting e.g. macOS older than release v11 Big Sur (which introduced
this funcitions), if the SDK declares it. Wrong detection will either
cause a binary broken on older macOS and/or trigger compiler warnings.

Ref: https://github.com/libressl/portable/issues/928#issuecomment-1850178282
Ref: https://github.com/libressl/portable/issues/928#issuecomment-1850276298

Prerequisite: #961
