### PR TITLE
pthreads.h: avoid undefined behavior

### DIFF
--- a/include/compat/pthread.h
+++ b/include/compat/pthread.h
@@ -30,18 +30,23 @@ struct pthread_once {
 };
 typedef struct pthread_once pthread_once_t;
 
+struct _pthread_win32_cb_arg {
+	void (*cb)(void);
+};
+
 static inline BOOL CALLBACK
 _pthread_once_win32_cb(PINIT_ONCE once, PVOID param, PVOID *context)
 {
-	void (*cb) (void) = param;
-	cb();
+	struct _pthread_win32_cb_arg *arg = param;
+	arg->cb();
 	return TRUE;
 }
 
 static inline int
 pthread_once(pthread_once_t *once, void (*cb) (void))
 {
-	BOOL rc = InitOnceExecuteOnce(&once->once, _pthread_once_win32_cb, cb, NULL);
+	struct _pthread_win32_cb_arg arg = { .cb = cb };
+	BOOL rc = InitOnceExecuteOnce(&once->once, _pthread_once_win32_cb, &arg, NULL);
 	if (rc == 0)
 		return -1;
 	else


### PR DESCRIPTION
You can't pass a function pointer through a void pointer. So wrap the pthread callback in a struct.

Fixes #966