### PR TITLE
ci: cleanup coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,48 +1,65 @@
-name: Coverity
+# GitHub Actions workflow to run Coverity scans.
+name: "Coverity"
 
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # At 00:00 daily.
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'libressl' }}
+    name: "Scan"
+    runs-on: "ubuntu-latest"
+    if: github.repository_owner == 'libressl' # Prevent running on forks
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@main
-    - name: Install apt dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake ninja-build
-    - name: Download Coverity build tool
-      run: |
-        wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=libressl-portable%2Fportable" -O coverity_tool.tar.gz
-        mkdir coverity_tool
-        tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
-    - name: Configure
-      run: |
-        ./autogen.sh
-        ./configure
-        make dist
-        tar zxf libressl-*.tar.gz
-        rm libressl-*.tar.gz
-        cd libressl-*
-        mkdir build-static
-        mkdir build-shared 
-        cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
-    - name: Build with Coverity build tool
-      run: |
-        export PATH=`pwd`/coverity_tool/bin:$PATH
-        cd libressl-*
-        cov-build --dir cov-int ninja
-    - name: Submit build result to Coverity Scan
-      run: |
-        cd libressl-*
-        tar czvf cov.tar.gz cov-int
-        curl --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
-          --form email=libressl-security@openbsd.org \
-          --form file=@cov.tar.gz \
-          --form version="Commit $GITHUB_SHA" \
-          --form description="Build submitted via CI" \
-          https://scan.coverity.com/builds?project=libressl-portable%2Fportable
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Install dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: "Download Coverity build tool"
+        env:
+          PROJECT: "libressl-portable%2Fportable"
+          COVERITY_SCAN_TOKEN: "${{ secrets.COVERITY_SCAN_TOKEN }}"
+        run: |
+          wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=$PROJECT" -O coverity_tool.tar.gz
+          mkdir coverity_tool
+          tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
+
+      - name: "Setup"
+        run: |
+          ./autogen.sh
+          ./configure
+          make dist
+          tar zxf libressl-*.tar.gz
+          rm libressl-*.tar.gz
+          cd libressl-*
+          mkdir build-static
+          mkdir build-shared 
+          cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
+
+      - name: "Build with Coverity build tool"
+        run: |
+          export PATH=`pwd`/coverity_tool/bin:$PATH
+          cd libressl-*
+          cov-build --dir cov-int ninja
+
+      - name: "Submit build result to Coverity Scan"
+        env:
+          EMAIL: "libressl-security@openbsd.org"
+          PROJECT: "libressl-portable%2Fportable"
+          COVERITY_SCAN_TOKEN: "${{ secrets.COVERITY_SCAN_TOKEN }}"
+        run: |
+          cd libressl-*
+          tar czvf cov.tar.gz cov-int
+          curl --form token=$COVERITY_SCAN_TOKEN \
+            --form email=$EMAIL \
+            --form file=@cov.tar.gz \
+            --form version="Commit $GITHUB_SHA" \
+            --form description="Build submitted via CI" \
+            https://scan.coverity.com/builds?project=$PROJECT


### PR DESCRIPTION
Cleans up `coverity` GitHub Actions workflow.

Changes:
 - Pin `actions/checkout` to `v4`
 - Restrict token permissions to `contents: read`
 - Overall tidy up
 - Use more common naming conventions