### PR TITLE
Compat: pthread.h shim for FreeRTOS

### DIFF
--- a/include/compat/freertosthreadcompat.h
+++ b/include/compat/freertosthreadcompat.h
@@ -10,11 +10,6 @@
 #include <FreeRTOS/semphr.h>
 #include <FreeRTOS/task.h>
 
-static inline uid_t getuid() {
-	return 0; 
-}
-
-
 // PTHREAD ONCE
 #define pthread_once libressl_pthread_once
 struct pthread_once {

--- a/include/compat/freertosthreadcompat.h
+++ b/include/compat/freertosthreadcompat.h
@@ -42,12 +42,14 @@ pthread_once(pthread_once_t *once, void (*cb) (void))
 #define pthread_t libressl_pthread_t
 typedef TaskHandle_t pthread_t;
 
+#define pthread_self libressl_pthread_self
 static inline pthread_t
 pthread_self(void)
 {
 	return xTaskGetCurrentTaskHandle();
 }
 
+#define pthread_equal libressl_pthread_equal
 static inline int
 pthread_equal(pthread_t t1, pthread_t t2)
 {
@@ -63,16 +65,17 @@ struct pthread_mutex {
 #define pthread_mutex_t libressl_pthread_mutex_t
 typedef struct pthread_mutex pthread_mutex_t;
 
-#define pthread_mutexattr libressl_mutexattr
+#define pthread_mutexattr libressl_pthread_mutexattr
 struct pthread_mutexattr {
 
 };
-#define pthread_mutexattr_t libressl_mutexattr_t
+#define pthread_mutexattr_t libressl_pthread_mutexattr_t
 typedef struct pthread_mutexattr pthread_mutexattr_t;
 
 
 #define PTHREAD_MUTEX_INITIALIZER { NULL }
 
+#define pthread_mutex_init libressl_pthread_mutex_init
 static inline int
 pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
 {
@@ -85,6 +88,7 @@ pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
 	return -1;
 }
 
+#define pthread_mutex_lock libressl_pthread_mutex_lock
 static inline int
 pthread_mutex_lock(pthread_mutex_t *mutex)
 {
@@ -102,6 +106,7 @@ pthread_mutex_lock(pthread_mutex_t *mutex)
     }
 }
 
+#define pthread_mutex_unlock libressl_pthread_mutex_unlock
 static inline int
 pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
@@ -118,6 +123,7 @@ pthread_mutex_unlock(pthread_mutex_t *mutex)
 	return 0;
 }
 
+#define pthread_mutex_destroy libressl_pthread_mutex_destroy
 static inline int
 pthread_mutex_destroy(pthread_mutex_t *mutex)
 {

--- a/include/compat/freertosthreadcompat.h
+++ b/include/compat/freertosthreadcompat.h
@@ -1,0 +1,139 @@
+#ifndef LIBCRYPTOCOMPAT_FREERTOSTHREADCOMPAT_H
+#define LIBCRYPTOCOMPAT_FREERTOSTHREADCOMPAT_H
+
+#ifdef FREERTOS
+
+#include <sys/types.h>
+
+#include <FreeRTOS/FreeRTOSConfig.h>
+#include <FreeRTOS/FreeRTOS.h>
+#include <FreeRTOS/semphr.h>
+#include <FreeRTOS/task.h>
+
+static inline uid_t getuid() {
+	return 0; 
+}
+
+
+// PTHREAD ONCE
+#define pthread_once libressl_pthread_once
+struct pthread_once {
+	int   is_initialized;
+	int   init_executed;
+};
+#define pthread_once_t libressl_pthread_once_t
+typedef struct pthread_once pthread_once_t;
+
+#define PTHREAD_ONCE_INIT { 1, 0 }
+
+static inline int
+pthread_once(pthread_once_t *once, void (*cb) (void))
+{
+	if (!once->is_initialized) {
+		return -1;
+	}
+
+	if (!once->init_executed) {
+		once->init_executed = 1;
+		cb();
+		return 0;
+	}
+
+	return -1;
+
+}
+
+// PTHREAD Support 
+#define pthread_t libressl_pthread_t
+typedef TaskHandle_t pthread_t;
+
+static inline pthread_t
+pthread_self(void)
+{
+	return xTaskGetCurrentTaskHandle();
+}
+
+static inline int
+pthread_equal(pthread_t t1, pthread_t t2)
+{
+	return t1 == t2;
+}
+
+
+// PTHREAD MUTEX Support
+#define pthread_mutex libressl_pthread_mutex
+struct pthread_mutex {
+	xSemaphoreHandle handle;
+};
+#define pthread_mutex_t libressl_pthread_mutex_t
+typedef struct pthread_mutex pthread_mutex_t;
+
+#define pthread_mutexattr libressl_mutexattr
+struct pthread_mutexattr {
+
+};
+#define pthread_mutexattr_t libressl_mutexattr_t
+typedef struct pthread_mutexattr pthread_mutexattr_t;
+
+
+#define PTHREAD_MUTEX_INITIALIZER { NULL }
+
+static inline int
+pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+	xSemaphoreHandle x = xSemaphoreCreateMutex();
+	if (x) {
+		mutex->handle = x;
+		return 0;
+	}
+
+	return -1;
+}
+
+static inline int
+pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+	xSemaphoreHandle x = mutex->handle;
+	if (x == NULL) {
+		x = xSemaphoreCreateMutex();
+		mutex->handle = x;
+	}
+
+	if ( xSemaphoreTake(x, portMAX_DELAY) == pdTRUE ) {
+        return 0;
+    }
+    else {
+        return -2;
+    }
+}
+
+static inline int
+pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+	xSemaphoreHandle x = mutex->handle;
+	if (x) {
+	    if ( xSemaphoreGive(x) == pdTRUE ) {
+	        return 0;
+	    }
+	    else {
+	    	return -1;
+	    }
+	}
+
+	return 0;
+}
+
+static inline int
+pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+	xSemaphoreHandle x = mutex->handle;
+	if (x) {
+		vQueueDelete(x);
+	}
+	mutex->handle = NULL;
+	return 0;
+}
+
+#endif
+
+#endif

--- a/include/compat/pthread.h
+++ b/include/compat/pthread.h
@@ -6,7 +6,9 @@
 #ifndef LIBCRYPTOCOMPAT_PTHREAD_H
 #define LIBCRYPTOCOMPAT_PTHREAD_H
 
-#ifdef _WIN32
+#if defined(FREERTOS)
+#include <freertosthreadcompat.h>
+#elif defined(_WIN32)
 
 #include <malloc.h>
 #include <stdlib.h>

--- a/include/compat/syslog.h
+++ b/include/compat/syslog.h
@@ -3,7 +3,11 @@
  * syslog.h compatibility shim
  */
 
-#ifndef _WIN32
+#if defined(_WIN32)
+#define NO_SYSLOG
+#elif defined(FREERTOS)
+#define NO_SYSLOG
+#else
 #include_next <syslog.h>
 #endif
 
@@ -14,7 +18,7 @@
 
 #include <stdarg.h>
 
-#ifdef _WIN32
+#ifdef NO_SYSLOG
 #define LOG_CONS	LOG_INFO
 #define	LOG_INFO	6	/* informational */
 #define LOG_USER    (1<<3)  /* random user-level messages */

--- a/include/compat/syslog.h
+++ b/include/compat/syslog.h
@@ -3,9 +3,7 @@
  * syslog.h compatibility shim
  */
 
-#if defined(_WIN32)
-#define NO_SYSLOG
-#elif defined(FREERTOS)
+#if defined(_WIN32) || defined(FREERTOS)
 #define NO_SYSLOG
 #else
 #include_next <syslog.h>

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -17,6 +17,10 @@ ssize_t pread(int d, void *buf, size_t nbytes, off_t offset);
 ssize_t pwrite(int d, const void *buf, size_t nbytes, off_t offset);
 #endif
 
+#elif defined(FREERTOS)
+static inline uid_t getuid(void) {
+       return 0;
+}
 #else
 
 #include <stdlib.h>


### PR DESCRIPTION
As discussed in #960.

Assumes that anyone wishing to build for FreeRTOS will define `FREERTOS` and ensure that the FreeRTOS headers are added to the include path at `FreeRTOS/___` 

-----

#### pthread_once
I wasn't sure if this has to be thread-safe. Can easily adjust this if required.

#### Syslog Support
I had to adjust the `compat/syslog.h` slighty to account for more than just Windows not providing syslog. Please let me know if there is a better/cleaner/more LibreSSLy way of doing things like this.

I liked making sure of the already defined `NO_SYSLOG` which is used as part of `crypto/compat/r_syslog.c` hence why this was picked. 

#### Sockets / Networking
We currently use the [LWIP](https://savannah.nongnu.org/projects/lwip/) networking stack. My plan was to submit another PR with a compatibility shim for that. As a result, I don't know the status of building for the built-in FreeRTOS stack. It's my understanding it follows the standard socket API so _might just work (TM)_...