### PR TITLE
ci: add concurrency groups to workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,10 @@ name: "Android"
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Test ${{ matrix.name }}"

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -3,6 +3,10 @@ name: CIFuzz
 on:
   workflow_dispatch:
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake_config.yml
+++ b/.github/workflows/cmake_config.yml
@@ -2,6 +2,10 @@ name: cmake_config
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   cmake-check:
     defaults:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "0 0 * * *" # At 00:00 daily.
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   scan:
     name: "Scan"

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -5,6 +5,10 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * *" # At 00:00 daily.
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   # Test against all supported architectures.
   test:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * 0" # At 00:00 weekly on Sunday.
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "${{ matrix.os }}/${{ matrix.arch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
   push:
     tags: [ "v*" ]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "0 0 * * *" # At 00:00 daily.
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Test"

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "0 0 * * *" # At 00:00 daily.
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Solaris"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * 0" # At 00:00 weekly on Sunday.
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "${{ matrix.os }}/${{ matrix.arch }} (${{ matrix.generator }})"


### PR DESCRIPTION
This pull request adds concurrency groups to all existing GitHub Actions workflows.

When a pull request is created, or a commit is pushed to a branch, all workflows related to that event are triggered. However, when subsequent commits are pushed to that pull request/branch, the workflow runs may be delayed until the previous workflow runs complete, due to GitHub's runner concurrency limit.

By adding concurrency groups to the workflows, we can automatically cancel all pending or running workflow runs related to previous commits, allowing workflow runs on newer commits to start faster.

This works by grouping each workflow run by the workflow name and git reference (branch/pull request). When concurrent workflow runs with the same group are queued, this will cause any previous pending or running jobs to be cancelled automatically (`cancel-in-progress: true`).

Related: https://docs.github.com/en/actions/using-jobs/using-concurrency