### PR TITLE
cmake: disable default NDEBUG differently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,13 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 	  STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# Enable asserts regardless of build type
-add_definitions(-UNDEBUG)
+# Do not disable assertions based on CMAKE_BUILD_TYPE
+foreach(_build_type "Release" "MinSizeRel" "RelWithDebInfo")
+	foreach(_lang C CXX)
+		string(TOUPPER "CMAKE_${_lang}_FLAGS_${_build_type}" _var)
+		string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " " ${_var} "${${_var}}")
+	endforeach()
+endforeach()
 
 set(BUILD_NC true)
 


### PR DESCRIPTION
This method allows to set it via custom flags.