### PR TITLE
Windows: Prevent assertion pop-up up when using Debug compiled libressl.

### DIFF
--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -164,8 +164,10 @@ static void noop_handler(const wchar_t *expression,	const wchar_t *function,
 }
 
 #define BEGIN_SUPPRESS_IPH \
+	int old_report_mode = _CrtSetReportMode(_CRT_ASSERT, 0); \
 	_invalid_parameter_handler old_handler = _set_thread_local_invalid_parameter_handler(noop_handler)
 #define END_SUPPRESS_IPH \
+	_CrtSetReportMode(_CRT_ASSERT, old_report_mode); \
 	_set_thread_local_invalid_parameter_handler(old_handler)
 
 #else


### PR DESCRIPTION
Hi, 

I tried to run the test suite in Debug mode on windows and had an assertion window pop. 

It happens when running the signertest, or the test project in  https://github.com/libressl/portable/issues/266. This was fixed in afcd4be8a72a for a release compiled library. To prevent the issue in debug mode, it looks like it is necessary to  also disable the assertion window popup. 

With this all tests pass when compiling and running them with a Debug, Release or RelWithDebInfo CMake build on windows (for me).