### PR TITLE
Windows: Don't set -Wall when compiling with Visual Studio.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,6 @@ if(WIN32)
 	endif()
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-
 if(CMAKE_SYSTEM_NAME MATCHES "HP-UX")
 	if(CMAKE_C_COMPILER MATCHES "gcc")
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing")
@@ -184,6 +182,8 @@ if(MSVC)
 		${MSVC_DISABLED_WARNINGS_LIST})
 	string(REGEX REPLACE "[/-]W[1234][ ]?" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -MP -W4 ${MSVC_DISABLED_WARNINGS_STR}")
+else()
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()
 
 check_function_exists(asprintf HAVE_ASPRINTF)


### PR DESCRIPTION
Hi, I noticed that -Wall is set when using visual studio, which enables a lot of spammed warnings like these (which are not part of the W4):

![image](https://github.com/libressl/portable/assets/10400536/70bed196-e23c-42dc-87db-e315e0cfc02e)

This reduces the warnings to W4, which are the ones that CI appears to use, if it makes sense.