### PR TITLE
fixup masm asm mneumonics in perl generator instead of update.sh

### DIFF
--- a/patches/asm/0001-align-read-only-sections-on-masm-windows-to-64-bytes.patch
+++ b/patches/asm/0001-align-read-only-sections-on-masm-windows-to-64-bytes.patch
@@ -1,14 +1,16 @@
-commit 3797e05de28ab07bb522898cbf022bdf67a71c99
-Author: Brent Cook <busterb@gmail.com>
-Date:   Sun Feb 4 22:53:59 2024 -0600
+From f46cbcb53dd94671184350d276ba99348116ddc3 Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Sun, 4 Feb 2024 22:53:59 -0600
+Subject: [PATCH 1/2] align read-only sections on masm/windows to 64 bytes
 
-    align read-only sections on masm/windows to 64 bytes
-    
-    Avoid conflicts where alignment is specified later in the underlying
-    assembly.
+Avoid conflicts where alignment is specified later in the underlying
+assembly.
+---
+ src/lib/libcrypto/perlasm/x86_64-xlate.pl | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/src/lib/libcrypto/perlasm/x86_64-xlate.pl b/src/lib/libcrypto/perlasm/x86_64-xlate.pl
-index 5dbed2a8c..d8b607b5c 100755
+index 325e7cf58..1e5475312 100755
 --- a/src/lib/libcrypto/perlasm/x86_64-xlate.pl
 +++ b/src/lib/libcrypto/perlasm/x86_64-xlate.pl
 @@ -567,7 +567,15 @@ my %globals;
@@ -28,3 +30,6 @@ index 5dbed2a8c..d8b607b5c 100755
  					} elsif ($line=~/\.CRT\$/i) {
  					    $v.=" READONLY ";
  					    $v.=$masm>=$masmref ? "ALIGN(8)" : "DWORD";
+-- 
+2.43.0
+

--- a/patches/asm/0002-fixup-masm-specific-operations-in-the-perl-generator.patch
+++ b/patches/asm/0002-fixup-masm-specific-operations-in-the-perl-generator.patch
@@ -1,0 +1,30 @@
+From 6495a168869f72d7a319bf1daa042c08a3dca65e Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Sun, 25 Feb 2024 11:21:50 -0600
+Subject: [PATCH 2/2] fixup masm-specific operations in the perl generator
+
+---
+ src/lib/libcrypto/perlasm/x86_64-xlate.pl | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/lib/libcrypto/perlasm/x86_64-xlate.pl b/src/lib/libcrypto/perlasm/x86_64-xlate.pl
+index 1e5475312..c68a466f3 100755
+--- a/src/lib/libcrypto/perlasm/x86_64-xlate.pl
++++ b/src/lib/libcrypto/perlasm/x86_64-xlate.pl
+@@ -815,6 +815,13 @@ while($line=<>) {
+     $line =~ s|/\*.*\*/||;	# ... and C-style comments...
+     $line =~ s|^\s+||;		# ... and skip white spaces in beginning
+ 
++	if ($masm) {
++		$line =~ s/^#/;/;
++		$line =~ s/|/OR/g;
++		$line =~ s/~/NOT/g;
++		$line =~ s/1 << \([0-9]*\)/1 SHL \1/g
++	}
++
+     undef $label;
+     undef $opcode;
+     undef @args;
+-- 
+2.43.0
+


### PR DESCRIPTION
removes dependency on cpp. Testing with newer masm, not running into the #include issues that were found years ago. Maybe we're good to remove this now.