### PR TITLE
deal with masm in a compatible way with openbsd's cpp

### DIFF
--- a/include/compat/cet.h
+++ b/include/compat/cet.h
@@ -1,0 +1,13 @@
+/*
+ * Public domain
+ * cet.h compatibility shim
+ */
+
+#ifndef LIBCOMPAT_CET_H
+#define LIBCOMPAT_CET_H
+
+#ifndef _MSC_VER
+#include_next <cet.h>
+#endif
+
+#endif

--- a/include/compat/cet.h
+++ b/include/compat/cet.h
@@ -7,7 +7,13 @@
 #define LIBCOMPAT_CET_H
 
 #ifndef _MSC_VER
-#include_next <cet.h>
+
+#ifdef __CET__
+#   include_next <cet.h>
+#else
+#   define _CET_ENDBR
+#endif
+
 #endif
 
 #endif

--- a/update.sh
+++ b/update.sh
@@ -186,7 +186,7 @@ $CP crypto/compat/ui_openssl_win.c crypto/ui
 $GREP -v OPENSSL_ia32cap_P $libcrypto_src/Symbols.list | $GREP '^[A-Za-z0-9_]' > crypto/crypto.sym
 
 fixup_masm() {
-	cpp -I./crypto -I./include/compat $1 \
+	cpp -I./crypto -I./include/compat -D_MSC_VER $1 \
 		| sed -e 's/^#/;/'    \
 		| sed -e 's/|/OR/g'   \
 		| sed -e 's/~/NOT/g'  \

--- a/update.sh
+++ b/update.sh
@@ -186,7 +186,7 @@ $CP crypto/compat/ui_openssl_win.c crypto/ui
 $GREP -v OPENSSL_ia32cap_P $libcrypto_src/Symbols.list | $GREP '^[A-Za-z0-9_]' > crypto/crypto.sym
 
 fixup_masm() {
-	cpp -I./crypto $1     \
+	cpp -I./crypto -I./include/compat $1 \
 		| sed -e 's/^#/;/'    \
 		| sed -e 's/|/OR/g'   \
 		| sed -e 's/~/NOT/g'  \


### PR DESCRIPTION
Try 2, it's difficult for now to remove the cpp dependency. Testing a cet.h shim which at least prevents us from leaking some host system details during the code generation phase.