### PR TITLE
put compat getpagesize into the right object list

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -734,7 +734,7 @@ if(NOT HAVE_GETOPT)
 endif()
 
 if(NOT HAVE_GETPAGESIZE)
-	set(CRYPTO_SRC ${CRYPTO_SRC} compat/getpagesize.c)
+	set(COMPAT_SRC ${COMPAT_SRC} compat/getpagesize.c)
 endif()
 
 if(NOT HAVE_GETPROGNAME)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -739,11 +739,11 @@ endif()
 
 if(NOT HAVE_GETPROGNAME)
 	if(WIN32)
-		set(CRYPTO_SRC ${CRYPTO_SRC} compat/getprogname_windows.c)
+		set(COMPAT_SRC ${COMPAT_SRC} compat/getprogname_windows.c)
 	elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
-		set(CRYPTO_SRC ${CRYPTO_SRC} compat/getprogname_linux.c)
+		set(COMPAT_SRC ${COMPAT_SRC} compat/getprogname_linux.c)
 	else()
-		set(CRYPTO_SRC ${CRYPTO_SRC} compat/getprogname_unimpl.c)
+		set(COMPAT_SRC ${COMPAT_SRC} compat/getprogname_unimpl.c)
 	endif()
 endif()
 
@@ -783,7 +783,7 @@ if(NOT HAVE_STRTONUM)
 endif()
 
 if(NOT HAVE_SYSLOG_R)
-	set(CRYPTO_SRC ${CRYPTO_SRC} compat/syslog_r.c)
+	set(COMPAT_SRC ${COMPAT_SRC} compat/syslog_r.c)
 endif()
 
 if(NOT HAVE_TIMEGM)


### PR DESCRIPTION
Was getting this linker error building shared libraries on Windows:

```
Creating library C:/projects/portable/build/ssl/Release/ssl.lib and object C:/projects/portable/build/ssl/Release/ssl.exp
recallocarray.obj : error LNK2019: unresolved external symbol getpagesize referenced in function
```

getpagesize should be in compat rather than crypto object file list.