### PR TITLE
Add `tests/bio_dump*` and `tests/x509_algor*` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ tests/asn1time*
 tests/asn1x509*
 tests/bio_asn1*
 tests/bio_chain*
+tests/bio_dump*
 tests/bio_host*
 tests/bio_mem*
 tests/bnaddsub*
@@ -133,6 +134,7 @@ tests/testssl
 tests/*.txt
 tests/compat/*.c
 tests/verify*
+tests/x509_algor*
 tests/x509_asn1*
 tests/x509_info*
 tests/x509attribute*


### PR DESCRIPTION
As 37d868b and 04fa997 added two new tests, this patch adds them to the gitignore to prevent from pushing copied files. 