### PR TITLE
Revert "CI: setup kernel entropy to work with asan"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,15 +57,6 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v4
 
-#
-# temporary hack
-# should be revisited after https://github.com/actions/runner-images/issues/9491 is resolved
-#
-
-      - name: Setup entropy
-        run: |
-          sudo sysctl vm.mmap_rnd_bits=28
-
       - name: "Run tests"
         run: ./scripts/test
         env:


### PR DESCRIPTION
This reverts commit cb2fd0abb21fc2ed4a725de0c57df25e10eee7e8 from #1019.