### PR TITLE
Add libssl and libcrypto to libtls's Libs.private

### DIFF
--- a/libtls.pc.in
+++ b/libtls.pc.in
@@ -9,5 +9,5 @@ Name: LibreSSL-libtls
 Description: Secure communications using the TLS socket protocol.
 Version: @VERSION@
 Libs: -L${libdir} -ltls
-Libs.private: @LIBS@ @PLATFORM_LDADD@
+Libs.private: @LIBS@ @PLATFORM_LDADD@ -lssl -lcrypto
 Cflags: -I${includedir}


### PR DESCRIPTION
Since d193f43 ("slim down `libtls`"), statically linking libtls requires also linking libssl and libcrypto, so express that in the pkg-config file.