### PR TITLE
mingw: re-enable endbr opcode, add workaround for llvm `cet.h` issue

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -193,7 +193,7 @@ if(HOST_ASM_MINGW64_X86_64)
 		whrlpool/wp-mingw64-x86_64.S
 		cpuid-mingw64-x86_64.S
 	)
-	add_definitions(-Dendbr64=)
+	add_definitions(-Dendbr32=endbr64)
 	add_definitions(-DAES_ASM)
 	add_definitions(-DBSAES_ASM)
 	add_definitions(-DVPAES_ASM)

--- a/crypto/Makefile.am.mingw64-x86_64
+++ b/crypto/Makefile.am.mingw64-x86_64
@@ -21,6 +21,7 @@ ASM_X86_64_MINGW64 += cpuid-mingw64-x86_64.S
 EXTRA_DIST += $(ASM_X86_64_MINGW64)
 
 if HOST_ASM_MINGW64_X86_64
+libcrypto_la_CPPFLAGS += -Dendbr32=endbr64
 libcrypto_la_CPPFLAGS += -DAES_ASM
 libcrypto_la_CPPFLAGS += -DBSAES_ASM
 libcrypto_la_CPPFLAGS += -DVPAES_ASM


### PR DESCRIPTION
- https://github.com/libressl/openbsd/pull/149 fixes to crash
  on startup issue, thus nuking all endbr opcodes is no longer
  necessary. This effectively enables CET in ASM code for
  MinGW x86_64 builds.
  A broader fix landed now via:
  https://github.com/openbsd/src/commit/db9cd57725789270c36763286ca8dc0a7c1b9d10

- llvm `cet.h` (as of v18) assigns `endbr32` instead of `endbr64`
  to `_CET_ENDBR` macro for MinGW x86_64 targets.
  https://github.com/llvm/llvm-project/blob/llvmorg-18.1.1/clang/lib/Headers/cet.h#L15-L35
  Work this around by mapping `endbr32` to `endbr64`.

Prerequisite: https://github.com/libressl/openbsd/pull/149
Fixes: https://github.com/libressl/portable/issues/1015
