### PR TITLE
temporarily undefine endbr* for stable branch macos/windows builds

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -111,6 +111,8 @@ if(HOST_ASM_MACOSX_X86_64)
 		bn/arch/amd64/word_clz.S
 		bn/arch/amd64/bn_arch.c
 	)
+	add_definitions(-Dendbr64=)
+	add_definitions(-Dendbr32=)
 	add_definitions(-DAES_ASM)
 	add_definitions(-DBSAES_ASM)
 	add_definitions(-DVPAES_ASM)
@@ -152,7 +154,6 @@ if(HOST_ASM_MASM_X86_64)
 		whrlpool/wp-masm-x86_64.S
 		cpuid-masm-x86_64.S
 	)
-	add_definitions(-Dendbr64=)
 	add_definitions(-DAES_ASM)
 	add_definitions(-DBSAES_ASM)
 	add_definitions(-DVPAES_ASM)
@@ -194,6 +195,7 @@ if(HOST_ASM_MINGW64_X86_64)
 		cpuid-mingw64-x86_64.S
 	)
 	add_definitions(-Dendbr64=)
+	add_definitions(-Dendbr32=)
 	add_definitions(-DAES_ASM)
 	add_definitions(-DBSAES_ASM)
 	add_definitions(-DVPAES_ASM)

--- a/crypto/Makefile.am.macosx-x86_64
+++ b/crypto/Makefile.am.macosx-x86_64
@@ -34,6 +34,8 @@ ASM_X86_64_MACOSX += bn/arch/amd64/bn_arch.c
 EXTRA_DIST += $(ASM_X86_64_MACOSX)
 
 if HOST_ASM_MACOSX_X86_64
+libcrypto_la_CPPFLAGS += -Dendbr64=
+libcrypto_la_CPPFLAGS += -Dendbr32=
 libcrypto_la_CPPFLAGS += -DAES_ASM
 libcrypto_la_CPPFLAGS += -DBSAES_ASM
 libcrypto_la_CPPFLAGS += -DVPAES_ASM

--- a/crypto/Makefile.am.mingw64-x86_64
+++ b/crypto/Makefile.am.mingw64-x86_64
@@ -21,6 +21,8 @@ ASM_X86_64_MINGW64 += cpuid-mingw64-x86_64.S
 EXTRA_DIST += $(ASM_X86_64_MINGW64)
 
 if HOST_ASM_MINGW64_X86_64
+libcrypto_la_CPPFLAGS += -Dendbr64=
+libcrypto_la_CPPFLAGS += -Dendbr32=
 libcrypto_la_CPPFLAGS += -DAES_ASM
 libcrypto_la_CPPFLAGS += -DBSAES_ASM
 libcrypto_la_CPPFLAGS += -DVPAES_ASM

--- a/update.sh
+++ b/update.sh
@@ -184,7 +184,7 @@ $CP crypto/compat/ui_openssl_win.c crypto/ui
 $GREP -v OPENSSL_ia32cap_P $libcrypto_src/Symbols.list | $GREP '^[A-Za-z0-9_]' > crypto/crypto.sym
 
 fixup_masm() {
-	cpp -I./crypto -I./include/compat -D_MSC_VER $1 \
+	cpp -I./crypto -I./include/compat -D_MSC_VER -U__CET__ $1 \
 		| sed -e 's/^#/;/'    \
 		| sed -e 's/|/OR/g'   \
 		| sed -e 's/~/NOT/g'  \


### PR DESCRIPTION
Testing getting the next stable release out without endbr*/CET enabled in asm code for now while #1032 is considered for upstream. This should also fix #1023 in the release tarballs.