### PR TITLE
explicitly undef __CET__ on masm cpp

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -184,7 +184,7 @@ $CP crypto/compat/ui_openssl_win.c crypto/ui
 $GREP -v OPENSSL_ia32cap_P $libcrypto_src/Symbols.list | $GREP '^[A-Za-z0-9_]' > crypto/crypto.sym
 
 fixup_masm() {
-	cpp -I./crypto -I./include/compat -D_MSC_VER $1 \
+	cpp -I./crypto -I./include/compat -D_MSC_VER -U__CET__ $1 \
 		| sed -e 's/^#/;/'    \
 		| sed -e 's/|/OR/g'   \
 		| sed -e 's/~/NOT/g'  \


### PR DESCRIPTION
Some systems (e.g. OpenBSD) unconditionally set __CET__ in the C preprocessor, which we don't want for masm yet. Eventually we need to figure out how to use the VS C preprocessor on assembly directly. This already went into the stable branches in #1033