### PR TITLE
Add `rm libressl-*.tar.gz` to test scripts/test

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -27,6 +27,7 @@ if [ `uname` = "Darwin" ]; then
 
 	# test cmake
 	tar zxvf libressl-*.tar.gz
+	rm libressl-*.tar.gz
 	cd libressl-*
 
 	(
@@ -62,6 +63,7 @@ elif [ "$ARCH" = "native" ]; then
 	make -j 4 distcheck
 
 	tar zxvf libressl-*.tar.gz
+	rm libressl-*.tar.gz
 	cd libressl-*
 
 


### PR DESCRIPTION
This patch adds `rm libressl-*.tar.gz`.

Currently some distribution (e.g. Fedora 39) `cd libressl-*` fails as:

```
+ cd libressl-3.9.0 libressl-3.9.0.tar.gz
./scripts/test: line 67: cd: too many arguments
```