### PR TITLE
[Windows] Mark old_report_mode as unused

### DIFF
--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -164,9 +164,10 @@ static void noop_handler(const wchar_t *expression,	const wchar_t *function,
 }
 
 #define BEGIN_SUPPRESS_IPH \
-	int old_report_mode = _CrtSetReportMode(_CRT_ASSERT, 0); \
-	_invalid_parameter_handler old_handler = _set_thread_local_invalid_parameter_handler(noop_handler)
+	const int old_report_mode = _CrtSetReportMode(_CRT_ASSERT, 0); \
+	const _invalid_parameter_handler old_handler = _set_thread_local_invalid_parameter_handler(noop_handler)
 #define END_SUPPRESS_IPH \
+	(void)old_report_mode; /* Silence warning in release mode when _CrtSetReportMode compiles to void. */ \
 	_CrtSetReportMode(_CRT_ASSERT, old_report_mode); \
 	_set_thread_local_invalid_parameter_handler(old_handler)
 


### PR DESCRIPTION
When compiling in release mode the _CrtSetReportMode macro gets replaced by void(0). This makes old_report_mode unused, which visual studio warns about.