### PR TITLE
use a specific version number in test scripts

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -4,7 +4,6 @@ set -x
 
 unset CC
 ENABLE_ASM="${ENABLE_ASM:=ON}"
-VERSION=`cat VERSION`
 
 if type apt-get >/dev/null 2>&1; then
 	sudo apt-get update
@@ -13,6 +12,8 @@ fi
 
 # generate source tree
 ./autogen.sh
+
+VERSION=`cat VERSION`
 
 if [ "$ARCH" = "" ]; then
 	ARCH=`uname -m`

--- a/scripts/test
+++ b/scripts/test
@@ -4,6 +4,7 @@ set -x
 
 unset CC
 ENABLE_ASM="${ENABLE_ASM:=ON}"
+VERSION=`cat VERSION`
 
 if type apt-get >/dev/null 2>&1; then
 	sudo apt-get update
@@ -26,8 +27,8 @@ if [ `uname` = "Darwin" ]; then
 	make -j 4 distcheck
 
 	# test cmake
-	tar zxvf libressl-*.tar.gz
-	cd libressl-*
+	tar zxvf libressl-$VERSION.tar.gz
+	cd libressl-$VERSION
 
 	(
 		mkdir build-static
@@ -61,8 +62,8 @@ elif [ "$ARCH" = "native" ]; then
 	# make distribution
 	make -j 4 distcheck
 
-	tar zxvf libressl-*.tar.gz
-	cd libressl-*
+	tar zxvf libressl-$VERSION.tar.gz
+	cd libressl-$VERSION
 
 
 	# test cmake and ninja

--- a/update.sh
+++ b/update.sh
@@ -149,7 +149,7 @@ else
 	$CP $libcrypto_src/opensslv.h include/openssl
 fi
 
-awk '/LIBRESSL_VERSION_TEXT/ {print $4}' < include/openssl/opensslv.h | cut -d\" -f1 > VERSION
+awk '/LIBRESSL_VERSION_TEXT/ {print $4}' < include/openssl/opensslv.h | cut -d\" -f1 | head -n1 > VERSION
 echo "LibreSSL version `cat VERSION`"
 
 # copy libcrypto source


### PR DESCRIPTION
This avoids issue reported in #1041 with file glob confusing `cd` in some cases.
Also remove extra newline from VERSION when update.sh runs.