### PR TITLE
Remove dead bitrig support, error on unsupported platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,10 @@ LT_INIT([pic-only])
 
 CHECK_OS_OPTIONS
 
+if test "$HOST_OS" = "unsupported"; then
+	AC_MSG_ERROR([unsupported platform: $host_os])
+fi
+
 CHECK_C_HARDENING_OPTIONS
 
 DISABLE_AS_EXECUTABLE_STACK

--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -109,7 +109,7 @@ char buf[1]; getentropy(buf, 1);
 		)
 		CPPFLAGS="$CPPFLAGS -D_OPENBSD_SOURCE"
 		;;
-	*openbsd* | *bitrig*)
+	*openbsd*)
 		HOST_OS=openbsd
 		HOST_ABI=elf
 		AC_DEFINE([HAVE_ATTRIBUTE__BOUNDED__], [1], [OpenBSD gcc has bounded])
@@ -131,7 +131,9 @@ char buf[1]; getentropy(buf, 1);
 		CPPFLAGS="$CPPFLAGS -D__EXTENSIONS__ -D_XOPEN_SOURCE=600 -DBSD_COMP"
 		AC_SUBST([PLATFORM_LDADD], ['-ldl -lmd -lnsl -lsocket'])
 		;;
-	*) ;;
+	*)
+		HOST_OS=unsupported
+		;;
 esac
 
 # Check if time_t is sized correctly


### PR DESCRIPTION
Fixes #1055 by failing earlier in the configuration process. Removes a long-dead BSD platform.