### PR TITLE
ci: add event number to concurrency group

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ name: "Android"
 on: [push, pull_request]
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cmake_config.yml
+++ b/.github/workflows/cmake_config.yml
@@ -3,7 +3,7 @@ name: cmake_config
 on: [push, pull_request]
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 * * *" # At 00:00 daily.
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -6,7 +6,7 @@ on:
   - cron: "0 0 * * *"
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * *" # At 00:00 daily.
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * 0" # At 00:00 weekly on Sunday.
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     tags: [ "v*" ]
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 * * *" # At 00:00 daily.
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 * * *" # At 00:00 daily.
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * 0" # At 00:00 weekly on Sunday.
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Add `github.event.number` to concurrency groups in CI workflows.
This should make sure that pushes to branches have separate groups than pull requests, and should prevent any conflicts that may cause unexpected skips/cancellations.
