### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -26,7 +26,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/cmake_config.yml
+++ b/.github/workflows/cmake_config.yml
@@ -37,7 +37,7 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install automake libtool
 
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - name: Prepare source tree for build (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: fedora:rawhide
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         dnf -y install git make clang cmake ninja-build autoconf automake libtool diffutils patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: "Create GitHub release"
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body_path: "${{ github.workspace }}/release-changelog.txt"
 
@@ -72,14 +72,10 @@ jobs:
         run: cmake --install build --config Release
 
       - shell: pwsh
-        run: Compress-Archive -Path local\* local.zip
+        run: Compress-Archive -Path local\* "libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip"
 
       - name: "Upload release artifact"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: "${{ github.token }}"
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: "${{ needs.release.outputs.upload_url }}"
-          asset_path: "local.zip"
-          asset_name: "libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip"
-          asset_content_type: "application/zip"
+          files: |
+            libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip


### PR DESCRIPTION
Update a few GitHub Actions to the latest versions. This includes some updates that change the version of Node used to run the actions, as Node.js 16 is EOL (https://nodejs.org/en/blog/announcements/nodejs16-eol, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

Additionally, use the `softprops/action-gh-release` action for uploading Windows release artifacts instead of [`actions/upload-release-asset`](https://github.com/actions/upload-release-asset) as it is deprecated.