### PR TITLE
Fix CMake build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	set(PLATFORM_LIBS ${PLATFORM_LIBS} pthread)
 endif()
 
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	set(PLATFORM_LIBS ${PLATFORM_LIBS} pthread)
+endif()
+
 if(WIN32)
 	set(BUILD_NC false)
 	if(MINGW)


### PR DESCRIPTION
FreeBSD's libc has a stub implementation of pthread_once() that returns ENOSYS and doesn't seem to call the init routine. You need to link with pthread for this to work.  This PR does this and fixes regress failures for CMake builds on this platform.  This likely never worked.