### PR TITLE
Assume unknown operating systems use ELF.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,10 +32,6 @@ LT_INIT([pic-only])
 
 CHECK_OS_OPTIONS
 
-if test "$HOST_OS" = "unsupported"; then
-	AC_MSG_ERROR([unsupported platform: $host_os])
-fi
-
 CHECK_C_HARDENING_OPTIONS
 
 DISABLE_AS_EXECUTABLE_STACK

--- a/configure.ac
+++ b/configure.ac
@@ -159,3 +159,7 @@ AM_CONDITIONAL([ENABLE_LIBTLS_ONLY], [test "x$enable_libtls_only" = xyes])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
 
 AC_OUTPUT
+
+if test "$HOST_OS" = "unsupported"; then
+       AC_MSG_WARN([unsupported platform: $host_os])
+fi

--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -132,7 +132,7 @@ char buf[1]; getentropy(buf, 1);
 		AC_SUBST([PLATFORM_LDADD], ['-ldl -lmd -lnsl -lsocket'])
 		;;
 	*)
-		HOST_OS=$host_os
+		HOST_OS=unsupported
 		HOST_ABI=elf
 		;;
 esac

--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -132,7 +132,8 @@ char buf[1]; getentropy(buf, 1);
 		AC_SUBST([PLATFORM_LDADD], ['-ldl -lmd -lnsl -lsocket'])
 		;;
 	*)
-		HOST_OS=unsupported
+		HOST_OS=$host_os
+		HOST_ABI=elf
 		;;
 esac
 


### PR DESCRIPTION
There's a lot of new Unix-like operating systems out that that might port LibreSSL (my Sortix is among them) and they all use ELF. If the operating system doesn't use ELF or isn't an Unix, it doesn't have a chance at working out of this box anyway, and this change makes LibreSSL work on a generic and sufficiently featured POSIX system.