### PR TITLE
Added CMake hint when searching for LibreSSL directory on macOS

### DIFF
--- a/FindLibreSSL.cmake
+++ b/FindLibreSSL.cmake
@@ -81,6 +81,11 @@ if (WIN32)
         "${_programfiles}/LibreSSL"
     )
     unset(_programfiles)
+elseif(APPLE)
+    # Homebrew installs LibreSSL here
+    set(_LIBRESSL_ROOT_PATHS
+        "/usr/local/opt/libressl"
+    )
 else()
     set(_LIBRESSL_ROOT_PATHS
         "/usr/local/"


### PR DESCRIPTION
The Homebrew package manager commonly used on macOS places LibreSSL in a known location, so this patch adds that directory to the search list in the CMake find script.

This makes it so macOS users do not have to directly set LIBRESSL_ROOT_DIR if they have installed it using Homebrew.