### PR TITLE
unset CC only for mingw and arm32

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,6 +32,9 @@ jobs:
           - os: "ubuntu-22.04"
             arch: "native"
             compiler: "clang"
+          - os: "ubuntu-24.04"
+            arch: "native"
+            compiler: "clang"
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4

--- a/scripts/test
+++ b/scripts/test
@@ -2,7 +2,10 @@
 set -e
 set -x
 
-unset CC
+if [ "$ARCH" = "mingw32" ] || [ "$ARCH" = "mingw64" ] || [ "$ARCH" = "arm32" ]; then
+	unset CC
+fi
+
 ENABLE_ASM="${ENABLE_ASM:=ON}"
 
 if type apt-get >/dev/null 2>&1; then

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,10 @@
 set -e
 set -x
 
+if [ "$ARCH" = "" ]; then
+	ARCH=`uname -m`
+fi
+
 if [ "$ARCH" = "mingw32" -o "$ARCH" = "mingw64" -o "$ARCH" = "arm32" ]; then
 	unset CC
 fi
@@ -17,10 +21,6 @@ fi
 ./autogen.sh
 
 VERSION=`cat VERSION`
-
-if [ "$ARCH" = "" ]; then
-	ARCH=`uname -m`
-fi
 
 # test macOS
 if [ `uname` = "Darwin" ]; then

--- a/scripts/test
+++ b/scripts/test
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-if [ "$ARCH" = "mingw32" ] || [ "$ARCH" = "mingw64" ] || [ "$ARCH" = "arm32" ]; then
+if [ "$ARCH" = "mingw32" -o "$ARCH" = "mingw64" -o "$ARCH" = "arm32" ]; then
 	unset CC
 fi
 


### PR DESCRIPTION
Since `scripts/test` always unset "CC", the github action for "clang"
in Linux does not use clang unintentionally.

This patch unset CC only for mingw{32,64} and arm32.