### PR TITLE
ci: remove use of ubuntu-20.04 runner image

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,13 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"]
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
         arch: ["native", "arm32", "arm64", "mingw32", "mingw64", "mips64"]
         compiler: ["gcc"]
         include:
-          - os: "ubuntu-20.04"
-            arch: "native"
-            compiler: "clang"
           - os: "ubuntu-22.04"
             arch: "native"
             compiler: "clang"


### PR DESCRIPTION
GitHub has started deprecating the `ubuntu-20.04` Actions runner image, and it will no longer work on 2025-04-01.
More information: https://github.com/actions/runner-images/issues/11101