### PR TITLE
ci: test on loongarch64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Run tests"
-        run: ./scripts/test
+        run: ./scripts/test || cat tests/test-suite.log
         env:
           ARCH: "${{ matrix.arch }}"
           CC: "${{ matrix.compiler }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,6 +36,10 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v4
 
+      - name: "Add universe repository"
+        if: matrix.arch == 'loong64'
+        run: sudo add-apt-repository universe
+
       - name: "Run tests"
         run: ./scripts/test
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "ubuntu-24.04"]
-        arch: ["native", "arm32", "arm64", "loong64", "mingw32", "mingw64", "mips64"]
+        arch: ["native", "arm32", "arm64", "mingw32", "mingw64", "mips64"]
         compiler: ["gcc"]
         include:
           - os: "ubuntu-22.04"
@@ -32,13 +32,12 @@ jobs:
           - os: "ubuntu-24.04"
             arch: "native"
             compiler: "clang"
+          - os: "ubuntu-24.04" # loong64
+            arch: "loong64"
+            compiler: "gcc"
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
-
-      - name: "Add universe repository"
-        if: matrix.arch == 'loong64'
-        run: sudo add-apt-repository universe
 
       - name: "Run tests"
         run: ./scripts/test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Run tests"
-        run: ./scripts/test || cat tests/test-suite.log
+        run: ./scripts/test || (status=$?; cat tests/test-suite.log; exit $status)
         env:
           ARCH: "${{ matrix.arch }}"
           CC: "${{ matrix.compiler }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "ubuntu-24.04"]
-        arch: ["native", "arm32", "arm64", "mingw32", "mingw64", "mips64"]
+        arch: ["native", "arm32", "arm64", "loong64", "mingw32", "mingw64", "mips64"]
         compiler: ["gcc"]
         include:
           - os: "ubuntu-22.04"

--- a/scripts/test
+++ b/scripts/test
@@ -134,7 +134,7 @@ elif [ "$ARCH" = "arm32" -o "$ARCH" = "arm64" ]; then
 
 elif [ "$ARCH" = "loong64" ]; then
 	sudo apt install -y qemu-user-static binfmt-support g++-14-loongarch64-linux-gnu
-	sudo ln -sf /usr/loongarch64-linux-gnu/lib/ld-linux-loongarch-lp64d.so.1 /lib
+	sudo ln -sf /usr/loongarch64-linux-gnu/lib64/ld-linux-loongarch-lp64d.so.1 /lib64
 
 	CC=loongarch64-linux-gnu-gcc-14
 	CXX=loongarch64-linux-gnu++-14

--- a/scripts/test
+++ b/scripts/test
@@ -132,6 +132,21 @@ elif [ "$ARCH" = "arm32" -o "$ARCH" = "arm64" ]; then
 
 	file apps/openssl/.libs/openssl
 
+elif [ "$ARCH" = "loong64" ]; then
+	sudo apt install -y qemu-user-static binfmt-support g++-14-loongarch64-linux-gnu
+	sudo ln -sf /usr/loongarch64-linux-gnu/lib/ld-linux-loongarch-lp64d.so.1 /lib
+
+	CC=loongarch64-linux-gnu-gcc-14
+	CXX=loongarch64-linux-gnu++-14
+	AR=loongarch64-linux-gnu-ar
+	STRIP=loongarch64-linux-gnu-strip-14
+	RANLIB=loongarch64-linux-gnu-ranlib
+
+	./configure --host=loongarch64-linux-gnu
+	LD_LIBRARY_PATH=/usr/loongarch64-linux-gnu/lib make -j 4 check
+
+	file apps/openssl/openssl
+
 elif [ "$ARCH" = "mips32" -o "$ARCH" = "mips64" ]; then
 	sudo apt-get install -y qemu-user-static binfmt-support
 

--- a/scripts/test
+++ b/scripts/test
@@ -133,13 +133,13 @@ elif [ "$ARCH" = "arm32" -o "$ARCH" = "arm64" ]; then
 	file apps/openssl/.libs/openssl
 
 elif [ "$ARCH" = "loong64" ]; then
-	sudo apt install -y qemu-user-static binfmt-support g++-loongarch64-linux-gnu
+	sudo apt install -y qemu-user-static binfmt-support g++-14-loongarch64-linux-gnu
 	sudo ln -sf /usr/loongarch64-linux-gnu/lib/ld-linux-loongarch-lp64d.so.1 /lib
 
-	CC=loongarch64-linux-gnu-gcc
-	CXX=loongarch64-linux-gnu++
+	CC=loongarch64-linux-gnu-gcc-14
+	CXX=loongarch64-linux-gnu++-14
 	AR=loongarch64-linux-gnu-ar
-	STRIP=loongarch64-linux-gnu-strip
+	STRIP=loongarch64-linux-gnu-strip-14
 	RANLIB=loongarch64-linux-gnu-ranlib
 
 	./configure --host=loongarch64-linux-gnu

--- a/scripts/test
+++ b/scripts/test
@@ -133,13 +133,13 @@ elif [ "$ARCH" = "arm32" -o "$ARCH" = "arm64" ]; then
 	file apps/openssl/.libs/openssl
 
 elif [ "$ARCH" = "loong64" ]; then
-	sudo apt install -y qemu-user-static binfmt-support g++-14-loongarch64-linux-gnu
+	sudo apt install -y qemu-user-static binfmt-support g++-loongarch64-linux-gnu
 	sudo ln -sf /usr/loongarch64-linux-gnu/lib/ld-linux-loongarch-lp64d.so.1 /lib
 
-	CC=loongarch64-linux-gnu-gcc-14
-	CXX=loongarch64-linux-gnu++-14
+	CC=loongarch64-linux-gnu-gcc
+	CXX=loongarch64-linux-gnu++
 	AR=loongarch64-linux-gnu-ar
-	STRIP=loongarch64-linux-gnu-strip-14
+	STRIP=loongarch64-linux-gnu-strip
 	RANLIB=loongarch64-linux-gnu-ranlib
 
 	./configure --host=loongarch64-linux-gnu


### PR DESCRIPTION
Add support for testing on `loongarch64` in the `/scripts/test` script and in GitHub Actions. This works by using GCC cross-compilation and QEMU to build and run the tests.

Currently compilation on `master` will fail, so this should be merged only after #1146 is merged.

Tested locally on #1146, all tests pass and the `file` output shows LoongArch:
```
============================================================================
Testsuite summary for libressl 4.1.0
============================================================================
# TOTAL: 136
# PASS:  136
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[3]: Leaving directory '/libressl/tests'
make[2]: Leaving directory '/libressl/tests'
make[1]: Leaving directory '/libressl/tests'
make[1]: Entering directory '/libressl'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/libressl'
+ file apps/openssl/openssl
apps/openssl/openssl: ELF 64-bit LSB executable, LoongArch, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-loongarch-lp64d.so.1, BuildID[sha1]=f666f5363db4c2f555f71d916ee459221f810e42, for GNU/Linux 5.19.0, with debug_info, not stripped
```

Note: The script uses "loong64" instead of "loongarch64". "loong64" is used by Go (where support is maintained by Loongson), Debian, etc. and is shorter. I don't mind changing it if anyone thinks we should use the longer name.

Also, I am not too familiar with automake/autoconfig/gcc, so if there's anyway this can be improved, please let me know.

Related to: #1146, #1123