### PR TITLE
.gitignore: ignore crypto/arch/* except for mips and loongarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,8 +238,8 @@ include/openssl/*.h
 !/apps/openssl/certhash_win.c
 
 /crypto/*
-/crypto/arch/
 !/crypto/Makefile.am.*
+/crypto/arch/
 !/crypto/arch/mips/*
 !/crypto/arch/loongarch64/*
 !/crypto/compat/

--- a/.gitignore
+++ b/.gitignore
@@ -238,9 +238,10 @@ include/openssl/*.h
 !/apps/openssl/certhash_win.c
 
 /crypto/*
+/crypto/arch/
 !/crypto/Makefile.am.*
-!/crypto/arch/
 !/crypto/arch/mips/*
+!/crypto/arch/loongarch64/*
 !/crypto/compat/
 /crypto/compat/*
 !/crypto/compat/arc4random.h


### PR DESCRIPTION
The arch/ directory is regenerated by autogen.sh and should generally be ignored. Only the mips and loongarch64 subdirectories are tracked in the portable tree because they are not supported by OpenBSD natively, but there has been interest in using LibreSSL on these architectures.

Fix https://github.com/libressl/portable/issues/1160