### PR TITLE
Remove x509name test in preparation for merge into x509_name_test.c

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -932,11 +932,6 @@ add_executable(x509_name_test x509_name_test.c)
 target_link_libraries(x509_name_test ${OPENSSL_TEST_LIBS})
 add_platform_test(x509_name_test x509_name_test)
 
-# x509name
-add_executable(x509name x509name.c)
-target_link_libraries(x509name ${OPENSSL_TEST_LIBS})
-add_platform_test(x509name x509name)
-
 # x509req_ext
 add_executable(x509req_ext x509req_ext.c)
 target_link_libraries(x509req_ext ${OPENSSL_TEST_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -917,11 +917,6 @@ TESTS += x509_name_test
 check_PROGRAMS += x509_name_test
 x509_name_test_SOURCES = x509_name_test.c
 
-# x509name
-TESTS += x509name
-check_PROGRAMS += x509name
-x509name_SOURCES = x509name.c
-
 # x509req_ext
 TESTS += x509req_ext
 check_PROGRAMS += x509req_ext


### PR DESCRIPTION
This change cleans up the old test infrastructure in preparation for consolidating the x509name.c test logic into x509_name_test.c.

Update CMakeLists.txt and Makefile.am accordingly.