### PR TITLE
update.sh: stop generating vpaes and bsaes x86_64 assembly

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -23,8 +23,6 @@ if(HOST_ASM_ELF_X86_64)
 	set(
 		ASM_X86_64_ELF_SRC
 		aes/aes-elf-x86_64.S
-		aes/bsaes-elf-x86_64.S
-		aes/vpaes-elf-x86_64.S
 		aes/aesni-elf-x86_64.S
 		bn/modexp512-elf-x86_64.S
 		bn/mont-elf-x86_64.S
@@ -60,8 +58,6 @@ if(HOST_ASM_MACOSX_X86_64)
 	set(
 		ASM_X86_64_MACOSX_SRC
 		aes/aes-macosx-x86_64.S
-		aes/bsaes-macosx-x86_64.S
-		aes/vpaes-macosx-x86_64.S
 		aes/aesni-macosx-x86_64.S
 		bn/modexp512-macosx-x86_64.S
 		bn/mont-macosx-x86_64.S
@@ -98,8 +94,6 @@ if(HOST_ASM_MASM_X86_64)
 	set(
 		ASM_X86_64_MASM_SRC
 		aes/aes-masm-x86_64.S
-		aes/bsaes-masm-x86_64.S
-		aes/vpaes-masm-x86_64.S
 		aes/aesni-masm-x86_64.S
 		#bn/modexp512-masm-x86_64.S
 		#bn/mont-masm-x86_64.S
@@ -124,8 +118,6 @@ if(HOST_ASM_MINGW64_X86_64)
 	set(
 		ASM_X86_64_MINGW64_SRC
 		aes/aes-mingw64-x86_64.S
-		aes/bsaes-mingw64-x86_64.S
-		aes/vpaes-mingw64-x86_64.S
 		aes/aesni-mingw64-x86_64.S
 		#bn/modexp512-mingw64-x86_64.S
 		#bn/mont-mingw64-x86_64.S

--- a/crypto/Makefile.am.elf-x86_64
+++ b/crypto/Makefile.am.elf-x86_64
@@ -1,7 +1,5 @@
 
 ASM_X86_64_ELF = aes/aes-elf-x86_64.S
-ASM_X86_64_ELF += aes/bsaes-elf-x86_64.S
-ASM_X86_64_ELF += aes/vpaes-elf-x86_64.S
 ASM_X86_64_ELF += aes/aesni-elf-x86_64.S
 ASM_X86_64_ELF += bn/modexp512-elf-x86_64.S
 ASM_X86_64_ELF += bn/mont-elf-x86_64.S

--- a/crypto/Makefile.am.macosx-x86_64
+++ b/crypto/Makefile.am.macosx-x86_64
@@ -1,7 +1,5 @@
 
 ASM_X86_64_MACOSX = aes/aes-macosx-x86_64.S
-ASM_X86_64_MACOSX += aes/bsaes-macosx-x86_64.S
-ASM_X86_64_MACOSX += aes/vpaes-macosx-x86_64.S
 ASM_X86_64_MACOSX += aes/aesni-macosx-x86_64.S
 ASM_X86_64_MACOSX += bn/modexp512-macosx-x86_64.S
 ASM_X86_64_MACOSX += bn/mont-macosx-x86_64.S

--- a/crypto/Makefile.am.masm-x86_64
+++ b/crypto/Makefile.am.masm-x86_64
@@ -1,7 +1,5 @@
 
 ASM_X86_64_MASM = aes/aes-masm-x86_64.S
-ASM_X86_64_MASM += aes/bsaes-masm-x86_64.S
-ASM_X86_64_MASM += aes/vpaes-masm-x86_64.S
 ASM_X86_64_MASM += aes/aesni-masm-x86_64.S
 ASM_X86_64_MASM += bn/modexp512-masm-x86_64.S
 ASM_X86_64_MASM += bn/mont-masm-x86_64.S

--- a/crypto/Makefile.am.mingw64-x86_64
+++ b/crypto/Makefile.am.mingw64-x86_64
@@ -1,7 +1,5 @@
 
 ASM_X86_64_MINGW64 = aes/aes-mingw64-x86_64.S
-ASM_X86_64_MINGW64 += aes/bsaes-mingw64-x86_64.S
-ASM_X86_64_MINGW64 += aes/vpaes-mingw64-x86_64.S
 ASM_X86_64_MINGW64 += aes/aesni-mingw64-x86_64.S
 #ASM_X86_64_MINGW64 += bn/modexp512-mingw64-x86_64.S
 #ASM_X86_64_MINGW64 += bn/mont-mingw64-x86_64.S

--- a/update.sh
+++ b/update.sh
@@ -276,8 +276,6 @@ for abi in elf macosx masm mingw64; do
 	echo generating x86_64 ASM source for $abi
 
 	gen_asm_stdout $abi aes/asm/aes-x86_64.pl        aes/aes-$abi-x86_64.S
-	gen_asm_stdout $abi aes/asm/vpaes-x86_64.pl      aes/vpaes-$abi-x86_64.S
-	gen_asm_stdout $abi aes/asm/bsaes-x86_64.pl      aes/bsaes-$abi-x86_64.S
 	gen_asm_stdout $abi aes/asm/aesni-x86_64.pl      aes/aesni-$abi-x86_64.S
 	gen_asm_stdout $abi bn/asm/modexp512-x86_64.pl   bn/modexp512-$abi-x86_64.S
 	gen_asm_stdout $abi bn/asm/x86_64-mont.pl        bn/mont-$abi-x86_64.S


### PR DESCRIPTION
Remove generation of vpaes and bsaes assembly sources from update.sh, as these are removed from source tree.

See: https://github.com/openbsd/src/commit/824f363240372afd9c86bea543128d656b531c16