### PR TITLE
Automake: use relative paths when linking object lists

### DIFF
--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -56,13 +56,13 @@ crypto_portable.sym: crypto.sym  Makefile
 
 libcrypto_la_objects.mk: Makefile
 	@echo "libcrypto_la_objects= $(libcrypto_la_OBJECTS)" \
-	  | sed 's/  */ $$\(abs_top_builddir\)\/crypto\//g' \
+	  | sed 's/  */ $$\(top_srcdir\)\/crypto\//g' \
 	  > libcrypto_la_objects.mk
 	@echo "libcompat_la_objects= $(libcompat_la_OBJECTS)" \
-	  | sed 's/compat\// $$\(abs_top_builddir\)\/crypto\/&/g' \
+	  | sed 's/compat\// $$\(top_srcdir\)\/crypto\/&/g' \
 	  >> libcrypto_la_objects.mk
 	@echo "libcompatnoopt_la_objects= $(libcompatnoopt_la_OBJECTS)" \
-	  | sed 's/compat\// $$\(abs_top_builddir\)\/crypto\/&/g' \
+	  | sed 's/compat\// $$\(top_srcdir\)\/crypto\/&/g' \
 	  >> libcrypto_la_objects.mk
 
 libcrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols crypto_portable.sym

--- a/ssl/Makefile.am
+++ b/ssl/Makefile.am
@@ -26,7 +26,7 @@ EXTRA_libssl_la_DEPENDENCIES = libssl_la_objects.mk
 
 libssl_la_objects.mk: Makefile
 	@echo "libssl_la_objects= $(libssl_la_OBJECTS)" \
-	  | sed 's/  */ $$\(abs_top_builddir\)\/ssl\//g' \
+	  | sed 's/  */ $$\(top_srcdir\)\/ssl\//g' \
 	  > libssl_la_objects.mk
 
 .PHONY: remove_bs_objects

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_libtls_la_DEPENDENCIES = libtls_la_objects.mk
 
 libtls_la_objects.mk: Makefile
 	@echo "libtls_la_objects= $(libtls_la_OBJECTS)" \
-	  | sed -e 's/ *$$//' -e 's/  */ $$\(abs_top_builddir\)\/tls\//g' \
+	  | sed -e 's/ *$$//' -e 's/  */ $$\(top_srcdir\)\/tls\//g' \
 	  > libtls_la_objects.mk
 
 libtls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined -export-symbols $(top_srcdir)/tls/tls.sym


### PR DESCRIPTION
This PR updates the automake-exported object lists to use relative paths instead of absolute paths.

This solves an issue when building the project from a directory with a longer absolute path (such as within a Bazel project in my use case), which can lead to an `Argument list too long` error due to the large amount of objects with long absolute paths given to `libtool`.