### PR TITLE
Limit usage of warning flags to C and C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ add_definitions(-D__END_HIDDEN_DECLS=)
 set(CMAKE_POSITION_INDEPENDENT_CODE true)
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-	add_compile_options(-Wno-pointer-sign)
+	add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-pointer-sign> $<$<COMPILE_LANGUAGE:C>:-Wno-pointer-sign>)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
`add_compile_options()` adds options to all compilers CMake can invoke, including ASM.  The format of this warning flag causes MASM to fail if the option is specified.  This limits specifying the warning suppression to just C and C++.