### PR TITLE
CI: Apply EVP const_ptr patch for LibreSSL < 4.2.0

### DIFF
--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -34,6 +34,10 @@ jobs:
       - name: "Run rust-openssl tests"
         run: |
           cd rust-openssl
+
+          # apply patch - see #1187
+          curl -L https://raw.githubusercontent.com/openbsd/ports/refs/heads/master/security/rust-openssl-tests/patches/patch-openssl-sys_src_handwritten_evp_rs | patch -p0
+
           # instead of erroring use the last supported version
           ed -s openssl-sys/build/main.rs <<-EOF
           /_ => version_error/-1


### PR DESCRIPTION
In the GitHub Actions workflow for rust-openssl testing, apply the patch used in OpenBSD ports to support `EVP_PKEY_get1_*` APIs with const_ptr. This ensures that the build succeeds before the official version bump to LibreSSL 4.2.0.

Fix https://github.com/libressl/portable/issues/1187