### PR TITLE
Improve {crypto,ssl}_namespace.h patches

### DIFF
--- a/patches/crypto_namespace.h.patch
+++ b/patches/crypto_namespace.h.patch
@@ -1,22 +1,25 @@
---- crypto/hidden/crypto_namespace.h.orig	Fri Aug  2 23:52:55 2024
-+++ crypto/hidden/crypto_namespace.h	Fri Aug  2 23:53:17 2024
-@@ -24,6 +24,12 @@
+--- crypto/hidden/crypto_namespace.h.orig	Sun Aug 17 13:14:19 2025
++++ crypto/hidden/crypto_namespace.h	Mon Aug 18 04:10:42 2025
+@@ -24,6 +24,10 @@
   * external calls use the latter name.
   */
  
 +#ifdef _MSC_VER
-+# define LCRYPTO_UNUSED(x)
-+# define LCRYPTO_USED(x)
-+# define LCRYPTO_ALIAS1(pre, x)
-+# define LCRYPTO_ALIAS(x)
-+#else
++#undef LIBRESSL_NAMESPACE
++#endif
++
  #ifdef LIBRESSL_NAMESPACE
  #ifdef LIBRESSL_CRYPTO_NAMESPACE
  #  define LCRYPTO_UNUSED(x)	__attribute__((deprecated))		\
-@@ -47,5 +53,6 @@
+@@ -45,7 +49,11 @@
+ # define LCRYPTO_UNUSED(x)
+ # define LCRYPTO_USED(x)
  # define LCRYPTO_ALIAS1(pre,x)
++#ifdef _MSC_VER
++# define LCRYPTO_ALIAS(x)
++#else
  # define LCRYPTO_ALIAS(x)	asm("")
- #endif
 +#endif /* _MSC_VER */
+ #endif
  
  #endif	/* _LIBCRYPTO_CRYPTO_NAMESPACE_H_ */

--- a/patches/ssl_namespace.h.patch
+++ b/patches/ssl_namespace.h.patch
@@ -1,21 +1,25 @@
---- ssl/hidden/ssl_namespace.h.orig	Fri Aug  2 23:52:55 2024
-+++ ssl/hidden/ssl_namespace.h	Fri Aug  2 23:53:17 2024
-@@ -23,6 +23,11 @@
+--- ssl/hidden/ssl_namespace.h.orig	Sun Aug 17 13:14:19 2025
++++ ssl/hidden/ssl_namespace.h	Mon Aug 18 04:11:53 2025
+@@ -23,6 +23,10 @@
   * and we alias that to the normal name.
   */
  
 +#ifdef _MSC_VER
-+#define LSSL_UNUSED(x)
-+#define LSSL_USED(x)
-+#define LSSL_ALIAS(x)
-+#else
++#undef LIBRESSL_NAMESPACE
++#endif
++
  #ifdef LIBRESSL_NAMESPACE
  #define LSSL_UNUSED(x)		typeof(x) x __attribute__((deprecated))
  #define LSSL_USED(x)		__attribute__((visibility("hidden")))	\
-@@ -37,5 +42,6 @@
+@@ -35,7 +39,11 @@
+ #else
+ #define LSSL_UNUSED(x)
  #define LSSL_USED(x)
++#ifdef _MSC_VER
++#define LSSL_ALIAS(x)
++#else
  #define LSSL_ALIAS(x)		asm("")
- #endif
 +#endif /* _MSC_VER */
+ #endif
  
  #endif	/* _LIBSSL_SSL_NAMESPACE_H_ */


### PR DESCRIPTION
This way we should be able to pull them into openbsd.