### PR TITLE
Fix inconsistencies in accept4.c

### DIFF
--- a/apps/nc/compat/accept4.c
+++ b/apps/nc/compat/accept4.c
@@ -6,10 +6,10 @@ accept4(int s, struct sockaddr *addr, socklen_t *addrlen, int flags)
 {
 	int rets = accept(s, addr, addrlen);
 	if (rets == -1)
-		return s;
+		return rets;
 
 	if (flags & SOCK_CLOEXEC) {
-		flags = fcntl(s, F_GETFD);
+		flags = fcntl(rets, F_GETFD);
 		fcntl(rets, F_SETFD, flags | FD_CLOEXEC);
 	}
 


### PR DESCRIPTION
Fix inconsistencies in accept4.c. If the underlying accept() fails the shim returns the listening socket s instead of −1.