### PR TITLE
Revert "CI: Apply EVP const_ptr patch for LibreSSL < 4.2.0"

### DIFF
--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -34,10 +34,6 @@ jobs:
       - name: "Run rust-openssl tests"
         run: |
           cd rust-openssl
-
-          # apply patch - see #1187
-          curl -L https://raw.githubusercontent.com/openbsd/ports/refs/heads/master/security/rust-openssl-tests/patches/patch-openssl-sys_src_handwritten_evp_rs | patch -p0
-
           # instead of erroring use the last supported version
           ed -s openssl-sys/build/main.rs <<-EOF
           /_ => version_error/-1


### PR DESCRIPTION
This reverts commit 5bcf54058d62ca1f197616ee344d05fbb3e34e21 (https://github.com/libressl/portable/pull/1188)
Since LibreSSL 4.2.0 has been released, the patch is no longer needed.
