### PR TITLE
Remove macos-13 CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-15", "macos-14", "macos-13"]
+        os: ["macos-15", "macos-14"]
         arch: ["arm64", "x86_64"]
     steps:
     - name: "Install required packages"


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/