### PR TITLE
ci: update and pin github actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
             max-nal: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Run CI script"
         run: ./scripts/test

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -26,7 +26,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/cmake-config.yml
+++ b/.github/workflows/cmake-config.yml
@@ -24,11 +24,11 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup Windows dependencies"
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         with:
           update: true
           install: >-

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -20,10 +20,10 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup emsdk"
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
           version: "3.1.60"
 
@@ -48,10 +48,10 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup emsdk"
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
           version: "3.1.60"
 

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: fedora:rawhide
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Install dependencies
       run: |
         dnf -y install git make clang cmake ninja-build autoconf automake libtool diffutils patch gawk

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup"
         run: |
@@ -31,7 +31,7 @@ jobs:
           ./autogen.sh
 
       - name: "Build on VM"
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@670398e4236735b8b65805c3da44b7a511fb8b27 # v1.3.0
         with:
           release: "${{ env.FREEBSD_VERSION }}"
           copyback: false
@@ -49,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup"
         run: |
@@ -58,7 +58,7 @@ jobs:
           ./autogen.sh
 
       - name: "Build on VM"
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@670398e4236735b8b65805c3da44b7a511fb8b27 # v1.3.0
         with:
           release: "${{ env.FREEBSD_VERSION }}"
           copyback: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Run tests"
         run: ./scripts/test || (status=$?; cat tests/test-suite.log; exit $status)
@@ -66,7 +66,7 @@ jobs:
         os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Run tests"
         run: ./scripts/test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
       run: brew install automake libtool
 
     - name: "Checkout repository"
-      uses: actions/checkout@v4
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: "Run tests"
       run: ./scripts/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       upload_url: "${{ steps.create_release.outputs.upload_url }}"
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Generate version changelog"
         run: .github/scripts/changelog.sh "$VERSION" > release-changelog.txt
@@ -29,7 +29,7 @@ jobs:
 
       - name: "Create GitHub release"
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           body_path: "${{ github.workspace }}/release-changelog.txt"
 
@@ -43,10 +43,10 @@ jobs:
         arch: [ "Win32", "x64", "ARM64" ]
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup MSYS2"
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         with:
           update: true
           install: >-
@@ -75,7 +75,7 @@ jobs:
         run: Compress-Archive -Path local\* "libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip"
 
       - name: "Upload release artifact"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: |
             libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip

--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Build LibreSSL"
         run: |

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup"
         run: |
@@ -28,7 +28,7 @@ jobs:
           ./autogen.sh
 
       - name: "Build on VM"
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@47bea106d03acaf91084e52548ee460556011602 # v1.1.8
         with:
           prepare: |
             pkg install gcc make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,10 +32,10 @@ jobs:
             generator: "Visual Studio 17 2022"
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: "Setup MSYS2"
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         with:
           update: true
           install: >-
@@ -64,7 +64,7 @@ jobs:
 
       - name: "Upload build artifacts"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: "${{ matrix.os }}-${{ matrix.arch }}${{ matrix.shared == 'ON' && '-shared' || '' }}-build-results"
           path: "build"


### PR DESCRIPTION
Update GitHub Actions to latest versions, and pin all used actions (except oss-fuzz) to full-length commit hashes to make them immutable. This prevents unexpected changes, and malicious updates or compromise of used actions.

https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

| Action                        | Update | Change                    |
|-------------------------------|--------|---------------------------|
| `actions/checkout`            | major  | `v4 -> v6.0.1 (8e8c483)`  |
| `actions/upload-artifact`     | major  | `v4 -> v6.0.0 (b7c566a)`  |
| `msys2/setup-msys2`           | pin    | `v2 -> v2.30.0 (4f806de)` |
| `mymindstorm/setup-emsdk`     | pin    | `v14 -> v14 (6ab9eb1)`    |
| `softprops/action-gh-release` | pin    | `v2 -> v2.5.0 (a06a81a)`  |
| `vmactions/freebsd-vm`        | pin    | `v1 -> v1.3.0 (670398e)`  |
| `vmactions/solaris-vm`        | pin    | `v1 -> v1.1.8 (47bea10)`  |
