### PR TITLE
scripts/test: fix missing env vars for cross-compilation

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -16,20 +16,19 @@ ENABLE_ASM="${ENABLE_ASM:=ON}"
 setup_cross_compiler() {
 	cross_prefix=$1
 
-	# Use unversioned symlink if available, otherwise find versioned binary
-	if command -v "${cross_prefix}-gcc" >/dev/null 2>&1; then
-		CC=${cross_prefix}-gcc
-		CXX=${cross_prefix}-g++
-	else
-		gcc_ver=$(find /usr/bin -name "${cross_prefix}-gcc-[0-9]*" -prune 2>/dev/null \
-			| sed "s/.*${cross_prefix}-gcc-//" | sort -n | tail -n 1)
-		CC=${cross_prefix}-gcc-${gcc_ver}
-		CXX=${cross_prefix}-g++-${gcc_ver}
-	fi
-
+	CC=${cross_prefix}-gcc
+	CXX=${cross_prefix}-g++
 	AR=${cross_prefix}-ar
 	STRIP=${cross_prefix}-strip
 	RANLIB=${cross_prefix}-ranlib
+
+	# If the unversioned symlink for gcc doesn't exist, find versioned binary.
+	if ! command -v "$CC" >/dev/null 2>&1; then
+		gcc_ver=$(find /usr/bin -name "${CC}-[0-9]*" -prune 2>/dev/null \
+			| sed "s/.*${CC}-//" | sort -n | tail -n 1)
+		CC=${CC}-${gcc_ver}
+		CXX=${CXX}-${gcc_ver}
+	fi
 
 	# Check all binaries actually exist.
 	for c in "$CC" "$CXX" "$AR" "$STRIP" "$RANLIB"; do
@@ -39,7 +38,7 @@ setup_cross_compiler() {
 		fi
 	done
 
-	echo "##### Using $($CC --version | head -1)"
+	echo "##### Using $($CC --version | head -n 1)"
 }
 
 if type apt-get >/dev/null 2>&1; then


### PR DESCRIPTION
Add missing `CC`, `CXX`, `AR`, `STRIP`, and `RANLIB` environment variables for cross-compilation in `scripts/test`. 

These fix a build failure when cross-compiling aarch64 assembly in https://github.com/libressl/portable/pull/1225: https://github.com/libressl/portable/actions/runs/21287021207/job/61270595453?pr=1225

Without these, the cross-compilation builds appear to be compiling for the native architecture (x86-64):
- arm32: https://github.com/joshuasing/libressl-portable/actions/runs/21318412669/job/61364617425#step:3:1659
- arm64: https://github.com/joshuasing/libressl-portable/actions/runs/21318412669/job/61364617401#step:3:1680
- mips32: https://github.com/joshuasing/libressl-portable/actions/runs/21318412669/job/61364617407#step:3:1655
- mips64: https://github.com/joshuasing/libressl-portable/actions/runs/21318412669/job/61364617426#step:3:1655

To verify this is now working correctly, the `file` output at the end of the tests shows the expected architecture.

While fixing these, this additionally:
- Use `||` for "or" in the elif-s instead of `-o`, as `-o` is not defined in POSIX.
- Fix path to `apps/openssl/openssl` for `file` command to validate the output arch.

Note: When testing mips32 after this change, `configure` kept failing. It appears `mipsel` (I think little-endian) was being used, but was not what is installed. I have updated the values to use just `mips`, but if this should use `mipsel` please let me know.