### PR TITLE
[DO NOT MERGE] Add `--unshallow` to git fetch in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -33,7 +33,7 @@ is_tag=$?
 # adjust for 9 hour time delta between trees
 release_ts=$((`git show -s --format=%ct $tag|tail -1` + 32400))
 commit=`git -C openbsd rev-list -n 1 --before=$release_ts $openbsd_branch`
-git -C openbsd fetch
+git -C openbsd fetch --unshallow
 if [ $is_tag -eq 0 ]; then
   echo "This is tag $tag, trying OpenBSD tag libressl-$tag"
   if ! git -C openbsd checkout "libressl-$tag"; then


### PR DESCRIPTION
When the openbsd repository is cloned with `--depth`, it becomes a shallow clone and lacks sufficient history to resolve commits based on timestamps.

Replace git fetch with git fetch --unshallow to ensure the commit history and branch are available.

Fix https://github.com/libressl/portable/issues/1233