### PR TITLE
Fix remote branch fetching and revision lookup in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,7 @@ openbsd_branch=`cat OPENBSD_BRANCH`
 # pull in latest upstream code
 echo "pulling upstream openbsd source"
 if [ ! -d openbsd ]; then
-	LIBRESSL_GIT_OPTIONS="${LIBRESSL_GIT_OPTIONS:- --depth=8}"
+	LIBRESSL_GIT_OPTIONS="${LIBRESSL_GIT_OPTIONS:- --depth=8 --no-single-branch}"
 	LIBRESSL_GIT="${LIBRESSL_GIT:- https://github.com/libressl}"
 	git clone $LIBRESSL_GIT_OPTIONS $LIBRESSL_GIT/openbsd
 fi
@@ -32,7 +32,7 @@ tag=`git describe --exact-match --tags HEAD 2>/dev/null`
 is_tag=$?
 # adjust for 9 hour time delta between trees
 release_ts=$((`git show -s --format=%ct $tag|tail -1` + 32400))
-commit=`git -C openbsd rev-list -n 1 --before=$release_ts $openbsd_branch`
+commit=`git -C openbsd rev-list -n 1 --before=$release_ts origin/$openbsd_branch`
 git -C openbsd fetch
 if [ $is_tag -eq 0 ]; then
   echo "This is tag $tag, trying OpenBSD tag libressl-$tag"


### PR DESCRIPTION
This patch changes to:

- add `--no-single-branch` to git clone to ensure all remote branches are tracked, allowing the script to switch between OpenBSD versions.

- use `origin/` prefix for $openbsd_branch to fix revision lookup At initial setup, the branch only exists as a "remote-tracking" reference. Since a local branch hasn't been created yet, git cannot find it by name alone. Adding the origin/ prefix explicitly tells git to look into the remote data we just fetched.

This ensures the script can correctly identify the commit hash based on the release timestamp even on a fresh shallow clone.

Fix https://github.com/libressl/portable/issues/1233