### PR TITLE
Add definition of ssize_t to cms.h for Windows

### DIFF
--- a/patches/cms.h.patch
+++ b/patches/cms.h.patch
@@ -1,0 +1,16 @@
+--- include/openssl/cms.h.orig	2026-02-20 16:35:58
++++ include/openssl/cms.h	2026-02-20 16:36:09
+@@ -67,6 +67,13 @@
+ extern "C" {
+ #endif
+
++#ifdef _MSC_VER
++#ifndef LIBRESSL_INTERNAL
++#include <basetsd.h>
++typedef SSIZE_T ssize_t;
++#endif
++#endif
++
+ typedef struct CMS_ContentInfo_st CMS_ContentInfo;
+ typedef struct CMS_SignerInfo_st CMS_SignerInfo;
+ typedef struct CMS_CertificateChoices CMS_CertificateChoices;


### PR DESCRIPTION
MSVC does not define ssize_t.
Hence, this patch adds a typedef for compatibility when LIBRESSL_INTERNAL is not defined.

Fix https://github.com/libressl/portable/issues/1232