### PR TITLE
ci: run tests on macos-26

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-15", "macos-14"]
+        os: ["macos-26", "macos-15", "macos-14"]
         arch: ["arm64", "x86_64"]
     steps:
     - name: "Install required packages"


### PR DESCRIPTION
Add `macos-26` (Tahoe) runner image to macOS workflow.

Apple is still providing security updates for macOS 14 (Sonoma), however to reduce the number of workflows running, maybe we want to consider removing it or only running `arm64` tests on older versions?

Currently all of the macOS images are Apple Silicon - GitHub now provides `-intel` images if we want to do some tests on older Intel-based hardware as well.