### PR TITLE
speed: fix SIGALRM handler not registered on Windows

### DIFF
--- a/patches/speed.c.patch
+++ b/patches/speed.c.patch
@@ -1,5 +1,5 @@
---- apps/openssl/speed.c.orig	2026-03-18 18:00:10
-+++ apps/openssl/speed.c	2026-03-18 18:00:28
+--- apps/openssl/speed.c.orig	2026-04-12 11:09:28
++++ apps/openssl/speed.c	2026-04-12 11:11:18
 @@ -156,7 +156,16 @@ static void print_result(int alg, int run_no, int coun
  pkey_print_message(const char *str, const char *str2,
      int bits, int sec);
@@ -65,7 +65,7 @@
  
  	if (j == 0) {
  		for (i = 0; i < ALGOR_NUM; i++) {
-@@ -1607,11 +1624,13 @@ speed_main(int argc, char **argv)
+@@ -1607,11 +1624,15 @@ speed_main(int argc, char **argv)
  #define COND	(run && count<0x7fffffff)
  #define COUNT(d) (count)
  
@@ -75,11 +75,13 @@
  	sa.sa_flags = SA_RESTART;
  	sa.sa_handler = sig_done;
  	sigaction(SIGALRM, &sa, NULL);
++#else
++	signal(SIGALRM, sig_done);
 +#endif
  
  #ifndef OPENSSL_NO_MD4
  	if (doit[D_MD4]) {
-@@ -2513,7 +2532,9 @@ speed_main(int argc, char **argv)
+@@ -2513,7 +2534,9 @@ speed_main(int argc, char **argv)
  		free(ss);
  	}
  
@@ -89,7 +91,7 @@
  	if (!mr) {
  		fprintf(stdout, "%s\n", SSLeay_version(SSLEAY_VERSION));
  		fprintf(stdout, "%s\n", SSLeay_version(SSLEAY_BUILT_ON));
-@@ -2695,11 +2716,15 @@ print_result(int alg, int run_no, int count, double ti
+@@ -2695,11 +2718,15 @@ print_result(int alg, int run_no, int count, double ti
  static void
  print_result(int alg, int run_no, int count, double time_used)
  {
@@ -105,7 +107,7 @@
  static char *
  sstrsep(char **string, const char *delim)
  {
-@@ -2900,5 +2925,6 @@ do_multi(int multi)
+@@ -2900,5 +2927,6 @@ do_multi(int multi)
  	free(fds);
  	return 1;
  }


### PR DESCRIPTION
On Windows, the `sigaction()` call is guarded by `#ifndef _WIN32`, but
there was no corresponding `#else` to register the signal handler via
`speed_signal()`.  This left `speed_alarm_handler` as `NULL`, causing
`speed_timer()` to call through a `NULL` function pointer and crash when
the alarm fired.

Add an `#else` branch that calls `signal(SIGALRM, sig_done)`, which is
remapped to `speed_signal()` by the macro defined in the `_WIN32` section,
so that `sig_done` is properly registered as the alarm handler before
any measurement loop begins.

FIx https://github.com/libressl/portable/issues/1243