### PR TITLE
ci: add renovate-bot config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,32 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:best-practices',
+    ':configMigration',
+    ':pinVersions',
+    ':rebaseStalePrs',
+    'schedule:weekends',
+    'customManagers:githubActionsVersions',
+    'helpers:pinGitHubActionDigests',
+  ],
+  commitMessagePrefix: 'ci:',
+  commitMessageAction: 'update',
+  commitMessageTopic: '{{depName}}',
+  labels: [
+    'dependencies',
+  ],
+  minimumReleaseAge: '3 days',
+  packageRules: [
+    {
+      matchUpdateTypes: ['pin', 'pinDigest'],
+      commitMessageAction: 'pin',
+    },
+  ],
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    enabled: true,
+    addLabels: [
+      'security',
+    ],
+  },
+}


### PR DESCRIPTION
Add `.github/renovate.json5` configuration file for Renovate automated dependency update PRs.

This configuration will cause Renovate to:
- create pull requests for pending updates on weekends
- pin updated versions
- only update dependencies once the new version has been available for >3 days, lowering risk of using a compromised version and providing time for security scanners/researchers to check updated versions
- rebase stale pull requests
- pin github actions to digests
- use commit message format `ci: update <dep> to v0.0.0`, or `ci: pin <dep> to <digest>`
- add `dependencies` label to pull requests, `security` label when the dependency update contains a security fix
- enable vulnerability alerts, which will create PRs bypassing the weekend schedule