### PR TITLE
Do not override user CFLAGS/LDFLAGS in hardening flag detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # This must be saved before AC_PROG_CC
 USER_CFLAGS="$CFLAGS"
+USER_LDFLAGS="$LDFLAGS"
 
 AC_PROG_CC([cc gcc])
 AM_PROG_CC_C_O

--- a/m4/check-hardening-options.m4
+++ b/m4/check-hardening-options.m4
@@ -3,7 +3,7 @@ AC_DEFUN([CHECK_CFLAG], [
 	 AC_LANG_ASSERT(C)
 	 AC_MSG_CHECKING([if $saved_CC supports "$1"])
 	 old_cflags="$CFLAGS"
-	 CFLAGS="$1 -Wall -Werror"
+	 CFLAGS="$USER_CFLAGS $1 -Wall -Werror"
 	 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[printf("Hello")]])],
 		     [AC_MSG_RESULT([yes])
 		     CFLAGS=$old_cflags
@@ -17,7 +17,7 @@ AC_DEFUN([CHECK_LDFLAG], [
 	 AC_LANG_ASSERT(C)
 	 AC_MSG_CHECKING([if $saved_LD supports "$1"])
 	 old_ldflags="$LDFLAGS"
-	 LDFLAGS="$1 -Wall -Werror"
+	 LDFLAGS="$USER_LDFLAGS $1 -Wall -Werror"
 	 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[printf("Hello")]])],
 		     [AC_MSG_RESULT([yes])
 		     LDFLAGS=$old_ldflags


### PR DESCRIPTION
`CHECK_CFLAG` / `CHECK_LDFLAG` overwrote `CFLAGS`/`LDFLAGS` with only the flag under test, so feature detection ran with a different target than the real build.

For example `CFLAGS=-march=i586 ./configure` accepted `-fcf-protection=full` (detected under the toolchain's i686 default) but then failed to compile because GCC 15 rejects `-fcf-protection` on i586.

Prepend `$USER_CFLAGS` / `$USER_LDFLAGS` (saved before `AC_PROG_CC`) to the detection command so the probe matches the real build.

Fixes #1268