### PR TITLE
clean up speed alarm from timer stop on Windows

### DIFF
--- a/patches/speed.c.patch
+++ b/patches/speed.c.patch
@@ -1,9 +1,9 @@
---- apps/openssl/speed.c.orig	2026-05-04 13:18:12
-+++ apps/openssl/speed.c	2026-05-04 13:29:58
-@@ -158,7 +158,16 @@ static double speed_timer_stop(void);
+--- apps/openssl/speed.c.orig	2026-05-05 10:27:21
++++ apps/openssl/speed.c	2026-05-05 10:34:44
+@@ -158,7 +158,16 @@ static double speed_timer_stop(int s);
  static void print_result(int alg, int run_no, int count, double time_used);
  static void speed_timer_start(int seconds);
- static double speed_timer_stop(void);
+ static double speed_timer_stop(int s);
 +#ifndef _WIN32
  static int do_multi(int multi);
 +#else
@@ -17,23 +17,23 @@
  
  #define SIZE_NUM	5
  #define MAX_ECDH_SIZE	256
-@@ -1008,7 +1017,15 @@ speed_timer_stop(void)
+@@ -1005,7 +1014,15 @@ speed_timer_stop(int s)
  static double
- speed_timer_stop(void)
+ speed_timer_stop(int s)
  {
 +#ifndef _WIN32
- 	return time_f(STOP);
+ 	return time_f(s);
 +#else
-+	double elapsed;
++ 	double elapsed;
 +
-+	elapsed = time_f(STOP);
++	elapsed = time_f(s);
 +	speed_alarm_free(run);
 +	return elapsed;
 +#endif
  }
  
  static const int KDF1_SHA1_len = 20;
-@@ -1126,8 +1143,10 @@ speed_main(int argc, char **argv)
+@@ -1123,8 +1140,10 @@ speed_main(int argc, char **argv)
  	const EVP_CIPHER *evp_cipher = NULL;
  	const EVP_MD *evp_md = NULL;
  	int decrypt = 0;
@@ -44,7 +44,7 @@
  	const char *errstr = NULL;
  
  	if (pledge("stdio proc", NULL) == -1) {
-@@ -1203,6 +1222,7 @@ speed_main(int argc, char **argv)
+@@ -1200,6 +1219,7 @@ speed_main(int argc, char **argv)
  			decrypt = 1;
  			j--;	/* Otherwise, -decrypt gets confused with an
  				 * algorithm. */
@@ -52,7 +52,7 @@
  		} else if (argc > 0 && strcmp(*argv, "-multi") == 0) {
  			argc--;
  			argv++;
-@@ -1217,6 +1237,7 @@ speed_main(int argc, char **argv)
+@@ -1214,6 +1234,7 @@ speed_main(int argc, char **argv)
  			}
  			j--;	/* Otherwise, -multi gets confused with an
  				 * algorithm. */
@@ -60,7 +60,7 @@
  		} else if (argc > 0 && strcmp(*argv, "-unaligned") == 0) {
  			argc--;
  			argv++;
-@@ -1540,7 +1561,9 @@ speed_main(int argc, char **argv)
+@@ -1537,7 +1558,9 @@ speed_main(int argc, char **argv)
  			BIO_printf(bio_err, "-evp e          use EVP e.\n");
  			BIO_printf(bio_err, "-decrypt        time decryption instead of encryption (only EVP).\n");
  			BIO_printf(bio_err, "-mr             produce machine readable output.\n");
@@ -70,7 +70,7 @@
  			BIO_printf(bio_err, "-unaligned n    use buffers with offset n from proper alignment.\n");
  			goto end;
  		}
-@@ -1549,8 +1572,10 @@ speed_main(int argc, char **argv)
+@@ -1546,8 +1569,10 @@ speed_main(int argc, char **argv)
  		j++;
  	}
  
@@ -81,7 +81,7 @@
  
  	if (j == 0) {
  		for (i = 0; i < ALGOR_NUM; i++) {
-@@ -1623,11 +1648,15 @@ speed_main(int argc, char **argv)
+@@ -1620,11 +1645,15 @@ speed_main(int argc, char **argv)
  #define COND	(run && count<0x7fffffff)
  #define COUNT(d) (count)
  
@@ -97,7 +97,7 @@
  
  #ifndef OPENSSL_NO_MD4
  	if (doit[D_MD4]) {
-@@ -2529,7 +2558,9 @@ speed_main(int argc, char **argv)
+@@ -2526,7 +2555,9 @@ speed_main(int argc, char **argv)
  		free(ss);
  	}
  
@@ -107,7 +107,7 @@
  	if (!mr) {
  		fprintf(stdout, "%s\n", SSLeay_version(SSLEAY_VERSION));
  		fprintf(stdout, "%s\n", SSLeay_version(SSLEAY_BUILT_ON));
-@@ -2714,6 +2745,7 @@ print_result(int alg, int run_no, int count, double ti
+@@ -2711,6 +2742,7 @@ print_result(int alg, int run_no, int count, double ti
  	results[alg][run_no] = ((double) count) / time_used * lengths[run_no];
  }
  
@@ -115,7 +115,7 @@
  static char *
  sstrsep(char **string, const char *delim)
  {
-@@ -2914,5 +2946,6 @@ do_multi(int multi)
+@@ -2911,5 +2943,6 @@ do_multi(int multi)
  	free(fds);
  	return 1;
  }

--- a/patches/speed.c.patch
+++ b/patches/speed.c.patch
@@ -1,9 +1,9 @@
---- apps/openssl/speed.c.orig	2026-04-12 11:09:28
-+++ apps/openssl/speed.c	2026-04-12 11:11:18
-@@ -156,7 +156,16 @@ static void print_result(int alg, int run_no, int coun
- pkey_print_message(const char *str, const char *str2,
-     int bits, int sec);
+--- apps/openssl/speed.c.orig	2026-05-04 13:18:12
++++ apps/openssl/speed.c	2026-05-04 13:29:58
+@@ -158,7 +158,16 @@ static double speed_timer_stop(void);
  static void print_result(int alg, int run_no, int count, double time_used);
+ static void speed_timer_start(int seconds);
+ static double speed_timer_stop(void);
 +#ifndef _WIN32
  static int do_multi(int multi);
 +#else
@@ -17,7 +17,23 @@
  
  #define SIZE_NUM	5
  #define MAX_ECDH_SIZE	256
-@@ -1110,8 +1119,10 @@ speed_main(int argc, char **argv)
+@@ -1008,7 +1017,15 @@ speed_timer_stop(void)
+ static double
+ speed_timer_stop(void)
+ {
++#ifndef _WIN32
+ 	return time_f(STOP);
++#else
++	double elapsed;
++
++	elapsed = time_f(STOP);
++	speed_alarm_free(run);
++	return elapsed;
++#endif
+ }
+ 
+ static const int KDF1_SHA1_len = 20;
+@@ -1126,8 +1143,10 @@ speed_main(int argc, char **argv)
  	const EVP_CIPHER *evp_cipher = NULL;
  	const EVP_MD *evp_md = NULL;
  	int decrypt = 0;
@@ -28,7 +44,7 @@
  	const char *errstr = NULL;
  
  	if (pledge("stdio proc", NULL) == -1) {
-@@ -1187,6 +1198,7 @@ speed_main(int argc, char **argv)
+@@ -1203,6 +1222,7 @@ speed_main(int argc, char **argv)
  			decrypt = 1;
  			j--;	/* Otherwise, -decrypt gets confused with an
  				 * algorithm. */
@@ -36,7 +52,7 @@
  		} else if (argc > 0 && strcmp(*argv, "-multi") == 0) {
  			argc--;
  			argv++;
-@@ -1201,6 +1213,7 @@ speed_main(int argc, char **argv)
+@@ -1217,6 +1237,7 @@ speed_main(int argc, char **argv)
  			}
  			j--;	/* Otherwise, -multi gets confused with an
  				 * algorithm. */
@@ -44,7 +60,7 @@
  		} else if (argc > 0 && strcmp(*argv, "-unaligned") == 0) {
  			argc--;
  			argv++;
-@@ -1524,7 +1537,9 @@ speed_main(int argc, char **argv)
+@@ -1540,7 +1561,9 @@ speed_main(int argc, char **argv)
  			BIO_printf(bio_err, "-evp e          use EVP e.\n");
  			BIO_printf(bio_err, "-decrypt        time decryption instead of encryption (only EVP).\n");
  			BIO_printf(bio_err, "-mr             produce machine readable output.\n");
@@ -54,7 +70,7 @@
  			BIO_printf(bio_err, "-unaligned n    use buffers with offset n from proper alignment.\n");
  			goto end;
  		}
-@@ -1533,8 +1548,10 @@ speed_main(int argc, char **argv)
+@@ -1549,8 +1572,10 @@ speed_main(int argc, char **argv)
  		j++;
  	}
  
@@ -65,7 +81,7 @@
  
  	if (j == 0) {
  		for (i = 0; i < ALGOR_NUM; i++) {
-@@ -1607,11 +1624,15 @@ speed_main(int argc, char **argv)
+@@ -1623,11 +1648,15 @@ speed_main(int argc, char **argv)
  #define COND	(run && count<0x7fffffff)
  #define COUNT(d) (count)
  
@@ -81,7 +97,7 @@
  
  #ifndef OPENSSL_NO_MD4
  	if (doit[D_MD4]) {
-@@ -2513,7 +2534,9 @@ speed_main(int argc, char **argv)
+@@ -2529,7 +2558,9 @@ speed_main(int argc, char **argv)
  		free(ss);
  	}
  
@@ -91,15 +107,7 @@
  	if (!mr) {
  		fprintf(stdout, "%s\n", SSLeay_version(SSLEAY_VERSION));
  		fprintf(stdout, "%s\n", SSLeay_version(SSLEAY_BUILT_ON));
-@@ -2695,11 +2718,15 @@ print_result(int alg, int run_no, int count, double ti
- static void
- print_result(int alg, int run_no, int count, double time_used)
- {
-+#ifdef _WIN32
-+	speed_alarm_free(run);
-+#endif
- 	BIO_printf(bio_err, mr ? "+R:%d:%s:%f\n"
- 	    : "%d %s in %.2fs\n", count, names[alg], time_used);
+@@ -2714,6 +2745,7 @@ print_result(int alg, int run_no, int count, double ti
  	results[alg][run_no] = ((double) count) / time_used * lengths[run_no];
  }
  
@@ -107,7 +115,7 @@
  static char *
  sstrsep(char **string, const char *delim)
  {
-@@ -2900,5 +2927,6 @@ do_multi(int multi)
+@@ -2914,5 +2946,6 @@ do_multi(int multi)
  	free(fds);
  	return 1;
  }

--- a/patches/speed.c.patch
+++ b/patches/speed.c.patch
@@ -1,8 +1,8 @@
---- apps/openssl/speed.c.orig	2026-05-05 10:27:21
-+++ apps/openssl/speed.c	2026-05-05 10:34:44
+--- apps/openssl/speed.c.orig	2026-05-05 10:50:46
++++ apps/openssl/speed.c	2026-05-05 10:51:24
 @@ -158,7 +158,16 @@ static double speed_timer_stop(int s);
  static void print_result(int alg, int run_no, int count, double time_used);
- static void speed_timer_start(int seconds);
+ static void speed_timer_start(int s);
  static double speed_timer_stop(int s);
 +#ifndef _WIN32
  static int do_multi(int multi);


### PR DESCRIPTION
The Windows speed alarm implementation owns thread and handle state that must be released after a benchmark run. Doing this from print_result() misses speed tests that report their results directly, which led to the leak reported in #1245.

Release the Windows alarm resources from speed_timer_stop() after recording the elapsed time, so the cleanup follows the benchmark timer lifetime without affecting the measured result.

Fix #1245