### PR TITLE
CI: prepare move of COVERITY_SCAN_TOKEN to environment

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   scan:
     name: "Scan"
+    environment:
+      name: "coverity"
+      deployment: false
     runs-on: "ubuntu-24.04"
     if: github.repository_owner == 'libressl' # Prevent running on forks
     permissions:


### PR DESCRIPTION
There is no need for this to be a repository secret as only the coverity workflow needs this.