### PR TITLE
allow releases to be retriggered on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ name: "Release"
 on:
   push:
     tags: [ "v*" ]
+  workflow_dispatch:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
Occasionally we might get a failure on the release job. I think this will add the correct option to allow retriggering in that case.