### PR TITLE
backport CI changes to OPENBSD_7_9 branch

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -39,7 +39,7 @@ jobs:
           path: "./out/artifacts"
 
       - name: "Upload SARIF"
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         if: always() && steps.build.outcome == 'success'
         with:
           sarif_file: "cifuzz-sarif/results.sarif"

--- a/.github/workflows/cmake-config.yml
+++ b/.github/workflows/cmake-config.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: "Setup Windows dependencies"
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           update: true
           install: >-

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   scan:
     name: "Scan"
+    environment:
+      name: "coverity"
+      deployment: false
     runs-on: "ubuntu-24.04"
     if: github.repository_owner == 'libressl' # Prevent running on forks
     permissions:

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'libressl' || github.event_name != 'schedule' }}
     container:
-      image: fedora:rawhide
+      image: fedora:rawhide@sha256:af8cdc432037f5e8e288bbc26c2b55b96000a911ec5b37959cd464d830f6cc5b
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install dependencies

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'libressl' || github.event_name != 'schedule' }}
     container:
-      image: fedora:rawhide@sha256:af8cdc432037f5e8e288bbc26c2b55b96000a911ec5b37959cd464d830f6cc5b
+      image: fedora:rawhide@sha256:8b838b3253cb855b1e5c3e1366fd0cda28cd1cc4c3517d625847172fd4ac6869
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Setup MSYS2"
-        uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           update: true
           install: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,37 +7,45 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
-  cancel-in-progress: true
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     name: "Release"
     runs-on: "ubuntu-24.04"
-    outputs:
-      upload_url: "${{ steps.create_release.outputs.upload_url }}"
+    permissions:
+      contents: write # Required to create release.
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Generate version changelog"
         run: .github/scripts/changelog.sh "$VERSION" > release-changelog.txt
         env:
           VERSION: "${{ github.ref_name }}"
 
-      - name: "Create GitHub release"
-        id: create_release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          body_path: "${{ github.workspace }}/release-changelog.txt"
+      - name: "Create draft GitHub release"
+        env:
+          GH_TOKEN: "${{ github.token }}"
+          VERSION: "${{ github.ref_name }}"
+        run: |
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$VERSION" \
+            --notes-file release-changelog.txt \
+            --draft
 
   build-windows:
     name: "${{ matrix.os }}/${{ matrix.arch }}"
     runs-on: "${{ matrix.os }}"
     needs: ["release"]
+    permissions:
+      contents: write # Required to upload release assets.
     strategy:
       matrix:
         os: [ "windows-2022" ]
@@ -45,6 +53,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Setup MSYS2"
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
@@ -60,23 +70,38 @@ jobs:
             patch
             perl
 
-      - shell: msys2 {0}
+      - name: "Run autogen"
+        shell: msys2 {0}
         run: ./autogen.sh
 
-      - shell: cmd
-        run: cmake -Bbuild -G "Visual Studio 17 2022" -A ${{ matrix.arch }} -DCMAKE_INSTALL_PREFIX=local
+      - name: "Configure"
+        shell: pwsh
+        env:
+          ARCH: "${{ matrix.arch }}"
+        run: cmake -Bbuild -G "Visual Studio 17 2022" -A "${env:ARCH}" -DCMAKE_INSTALL_PREFIX=local
 
-      - shell: cmd
+      - name: "Build"
+        shell: pwsh
         run: cmake --build build --config Release
 
-      - shell: cmd
+      - name: "Install"
+        shell: pwsh
         run: cmake --install build --config Release
 
-      - shell: pwsh
-        run: Compress-Archive -Path local\* "libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip"
+      - name: "Package release artifact"
+        shell: pwsh
+        env:
+          VERSION: "${{ github.ref_name }}"
+          ARCH: "${{ matrix.arch }}"
+        run: Compress-Archive -Path local\* "libressl_${env:VERSION}_windows_${env:ARCH}.zip"
 
       - name: "Upload release artifact"
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          files: |
-            libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip
+        shell: bash
+        env:
+          GH_TOKEN: "${{ github.token }}"
+          VERSION: "${{ github.ref_name }}"
+          ARCH: "${{ matrix.arch }}"
+        run: |
+          gh release upload "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            "libressl_${VERSION}_windows_${ARCH}.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Create GitHub release"
         id: create_release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           body_path: "${{ github.workspace }}/release-changelog.txt"
 
@@ -76,7 +76,7 @@ jobs:
         run: Compress-Archive -Path local\* "libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip"
 
       - name: "Upload release artifact"
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: |
             libressl_${{ github.ref_name }}_windows_${{ matrix.arch }}.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Setup MSYS2"
-        uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           update: true
           install: >-


### PR DESCRIPTION
This cherry-picks some of the changes from the main branch back to OPENBSD_7_9, the more important of these being the change to make the release a draft instead of final so that other artifacts can be uploaded prior to release.

Let me know if I missed anything else important.