### PR TITLE
ci: fix coverity build tool download URL

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -34,7 +34,7 @@ jobs:
           PROJECT: "libressl-portable%2Fportable"
           COVERITY_SCAN_TOKEN: "${{ secrets.COVERITY_SCAN_TOKEN }}"
         run: |
-          wget -nv https://scan.coverity.com/download/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=$PROJECT" -O coverity_tool.tar.gz
+          wget -nv https://scan.coverity.com/download/cxx/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=$PROJECT" -O coverity_tool.tar.gz
           mkdir coverity_tool
           tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
 


### PR DESCRIPTION
Coverity Scan now serves the C/C++ Linux build tool from `/download/cxx/linux64`. The old `/download/linux64` endpoint returns 404, causing the Coverity workflow to fail before the build starts.

Update the workflow to use the C/C++ download endpoint.