### PR TITLE
Allow overriding TLS_DEFAULT_CA_FILE in CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ option(ENABLE_ASM "Enable assembly" ON)
 option(ENABLE_EXTRATESTS "Enable extra tests that may be unreliable on some platforms" OFF)
 option(ENABLE_NC "Enable installing TLS-enabled nc(1)" OFF)
 set(OPENSSLDIR ${OPENSSLDIR} CACHE PATH "Set the default openssl directory" FORCE)
+set(TLS_DEFAULT_CA_FILE ${TLS_DEFAULT_CA_FILE} CACHE PATH "Set the default CA file" FORCE)
 set(LIBRESSL_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/LibreSSL" CACHE STRING "Installation directory for the CMake targets")
 
 option(USE_STATIC_MSVC_RUNTIMES "Use /MT instead of /MD in MSVC" OFF)
@@ -504,6 +505,10 @@ if(OPENSSLDIR STREQUAL "")
 	set(CONF_DIR "${CMAKE_INSTALL_SYSCONFDIR}/ssl")
 else()
 	set(CONF_DIR "${OPENSSLDIR}")
+endif()
+
+if(TLS_DEFAULT_CA_FILE STREQUAL "")
+	set(TLS_DEFAULT_CA_FILE "${OPENSSLDIR}/cert.pem")
 endif()
 
 add_subdirectory(include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option(ENABLE_ASM "Enable assembly" ON)
 option(ENABLE_EXTRATESTS "Enable extra tests that may be unreliable on some platforms" OFF)
 option(ENABLE_NC "Enable installing TLS-enabled nc(1)" OFF)
 set(OPENSSLDIR ${OPENSSLDIR} CACHE PATH "Set the default openssl directory" FORCE)
-set(TLS_DEFAULT_CA_FILE ${TLS_DEFAULT_CA_FILE} CACHE PATH "Set the default CA file" FORCE)
+set(TLS_DEFAULT_CA_FILE ${TLS_DEFAULT_CA_FILE} CACHE PATH "Set the default CA file for libtls" FORCE)
 set(LIBRESSL_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/LibreSSL" CACHE STRING "Installation directory for the CMake targets")
 
 option(USE_STATIC_MSVC_RUNTIMES "Use /MT instead of /MD in MSVC" OFF)

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -41,7 +41,7 @@ if(WIN32)
 	set(TLS_COMPAT_SRC ${TLS_COMPAT_SRC} compat/pwrite.c)
 endif()
 
-add_definitions(-DTLS_DEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
+add_definitions(-DTLS_DEFAULT_CA_FILE=\"${TLS_DEFAULT_CA_FILE}\")
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tls.sym DESTINATION
 	${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The CMake build unconditionally defined `TLS_DEFAULT_CA_FILE` as `${OPENSSLDIR}/cert.pem`, so a value supplied with `-DTLS_DEFAULT_CA_FILE` was ignored.

Add `TLS_DEFAULT_CA_FILE` as a cache variable and use it for the libtls definition, falling back to `${OPENSSLDIR}/cert.pem` when unset.

Fix https://github.com/libressl/portable/issues/1295