### PR TITLE
fix out-of-bounds write in getdelim on undersized buffer

### DIFF
--- a/crypto/compat/getdelim.c
+++ b/crypto/compat/getdelim.c
@@ -38,10 +38,18 @@ getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
 	char *ptr, *eptr;
 
 
-	if (*buf == NULL || *bufsiz == 0) {
-		*bufsiz = BUFSIZ;
-		if ((*buf = malloc(*bufsiz)) == NULL)
+	/*
+	 * Ensure the buffer can hold at least one byte plus the NUL
+	 * terminator before the loop writes to it.  A caller-supplied
+	 * buffer smaller than that is grown rather than overrun.
+	 */
+	if (*buf == NULL || *bufsiz < 2) {
+		char *nbuf;
+		size_t nbufsiz = BUFSIZ;
+		if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
 			return -1;
+		*buf = nbuf;
+		*bufsiz = nbufsiz;
 	}
 
 	for (ptr = *buf, eptr = *buf + *bufsiz;;) {

--- a/crypto/compat/getdelim.c
+++ b/crypto/compat/getdelim.c
@@ -35,17 +35,12 @@
 ssize_t
 getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
 {
-	char *ptr, *eptr;
+	char *ptr, *eptr, *nbuf;
+	size_t nbufsiz;
 
 
-	/*
-	 * Ensure the buffer can hold at least one byte plus the NUL
-	 * terminator before the loop writes to it.  A caller-supplied
-	 * buffer smaller than that is grown rather than overrun.
-	 */
 	if (*buf == NULL || *bufsiz < 2) {
-		char *nbuf;
-		size_t nbufsiz = BUFSIZ;
+		nbufsiz = BUFSIZ;
 		if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
 			return -1;
 		*buf = nbuf;
@@ -70,9 +65,8 @@ getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
 			return ptr - *buf;
 		}
 		if (ptr + 2 >= eptr) {
-			char *nbuf;
-			size_t nbufsiz = *bufsiz * 2;
 			ssize_t d = ptr - *buf;
+			nbufsiz = *bufsiz * 2;
 			if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
 				return -1;
 			*buf = nbuf;


### PR DESCRIPTION
getdelim only (re)allocates when *buf is NULL or *bufsiz is 0, so a too-small caller-supplied buffer slips through:
- a one-byte heap buffer with *bufsiz == 1 is left untouched
- when the first byte read equals the delimiter, the NUL terminator is written at buf[1], one past the end
- getline() inherits this since it calls getdelim()

Grow the buffer to BUFSIZ whenever it cannot hold a byte plus its terminator. AddressSanitizer flags the write at getdelim.c (heap-buffer-overflow, one byte past a one-byte region) before the change and runs clean after.