### PR TITLE
guard getdelim buffer growth against size_t overflow

### DIFF
--- a/crypto/compat/getdelim.c
+++ b/crypto/compat/getdelim.c
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -66,6 +68,10 @@ getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
 		}
 		if (ptr + 2 >= eptr) {
 			ssize_t d = ptr - *buf;
+			if (*bufsiz > SIZE_MAX / 2) {
+				errno = EOVERFLOW;
+				return -1;
+			}
 			nbufsiz = *bufsiz * 2;
 			if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
 				return -1;


### PR DESCRIPTION
The buffer-growth path in getdelim doubles the size without an overflow check:
- once *bufsiz reaches SIZE_MAX/2 (roughly 2 GiB of input on a 32-bit size_t), `*bufsiz * 2` wraps to a small value or zero
- realloc then hands back an undersized buffer while ptr has already been advanced d bytes in, so the next stored byte lands past the allocation
- distinct from the initial-allocation overflow in #1309; this one is the growth branch (`nbufsiz = *bufsiz * 2`)

Reject the growth with EOVERFLOW before the multiply can wrap, matching the size_t overflow guard already used in dirent_msvc.h.