### PR TITLE
handle GetModuleFileName failure in getprogname

### DIFF
--- a/crypto/compat/getprogname_windows.c
+++ b/crypto/compat/getprogname_windows.c
@@ -7,7 +7,8 @@ getprogname(void)
 {
 	static char progname[MAX_PATH + 1];
 	DWORD length = GetModuleFileName(NULL, progname, sizeof (progname) - 1);
-	if (length < 0)
+	if (length == 0)
 		return "?";
+	progname[length] = '\0';
 	return progname;
 }


### PR DESCRIPTION
GetModuleFileName returns an unsigned DWORD, so the error branch never runs:
- length < 0 is always false, so a failed call is not detected
- that falls through and returns the empty or stale static buffer instead of "?"
- terminate progname at the returned length rather than relying on the trailing static-zero byte