### PR TITLE
hook up x509/verify regress test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,10 +140,14 @@ tests/test.h
 tests/*test.c
 tests/pbkdf2*
 tests/*.pem
+tests/certs/
+tests/make-dir-roots.pl
 tests/testssl
 tests/*.txt
 tests/compat/*.c
 tests/verify*
+tests/x509_verify*
+!tests/x509_verify.sh
 tests/x509_algor*
 tests/x509_asn1*
 tests/x509_crl*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -931,6 +931,23 @@ add_executable(valid_handshakes_terminate valid_handshakes_terminate.c)
 target_link_libraries(valid_handshakes_terminate ${OPENSSL_TEST_LIBS})
 add_platform_test(valid_handshakes_terminate valid_handshakes_terminate)
 
+# x509_verify
+add_executable(x509_verify x509_verify.c)
+target_link_libraries(x509_verify ${OPENSSL_TEST_LIBS})
+add_dependencies(x509_verify openssl)
+if(NOT WIN32 AND NOT EMSCRIPTEN)
+	add_test(NAME x509_verify COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/x509_verify.sh
+	    $<TARGET_FILE:x509_verify> $<TARGET_FILE:openssl>)
+	set_tests_properties(x509_verify PROPERTIES
+	    ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}"
+	    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+	# This test depends on certificate times that can exceed 32-bit time_t
+	# range, so match the existing time tests and expect failure there.
+	if(SMALL_TIME_T)
+		set_property(TEST x509_verify PROPERTY WILL_FAIL TRUE)
+	endif()
+endif()
+
 # verifytest
 add_executable(verifytest verifytest.c)
 target_link_libraries(verifytest ${LIBTLS_TEST_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -102,6 +102,9 @@ check_PROGRAMS =
 EXTRA_DIST = CMakeLists.txt
 DISTCLEANFILES = pidwraptest.txt
 
+distclean-local:
+	rm -rf x509_verify-certs
+
 # XXX - should probably be in their own static lib
 TEST_HELPER_SRC = test.c test_util.c
 noinst_HEADERS = test.h
@@ -914,6 +917,19 @@ utf8test_SOURCES = utf8test.c
 TESTS += valid_handshakes_terminate
 check_PROGRAMS += valid_handshakes_terminate
 valid_handshakes_terminate_SOURCES = valid_handshakes_terminate.c
+
+# x509_verify
+# This test depends on certificate times that can exceed 32-bit time_t
+# range, so match the existing time tests and expect failure there.
+if SMALL_TIME_T
+XFAIL_TESTS += x509_verify.sh
+endif
+TESTS += x509_verify.sh
+check_PROGRAMS += x509_verify
+x509_verify_SOURCES = x509_verify.c
+EXTRA_DIST += x509_verify.sh
+EXTRA_DIST += make-dir-roots.pl
+EXTRA_DIST += certs
 
 # verifytest
 TESTS += verifytest

--- a/tests/x509_verify.sh
+++ b/tests/x509_verify.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Kenjiro Nakayama
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -e
+
+if [ -z "$srcdir" ]; then
+	srcdir=.
+fi
+
+case "$srcdir" in
+/*)
+	certs_path="$srcdir/certs"
+	make_dir_roots="$srcdir/make-dir-roots.pl"
+	openssl_conf="$srcdir/openssl.cnf"
+	;;
+*)
+	certs_path="`pwd`/$srcdir/certs"
+	make_dir_roots="`pwd`/$srcdir/make-dir-roots.pl"
+	openssl_conf="`pwd`/$srcdir/openssl.cnf"
+	;;
+esac
+
+if [ $# -ge 1 ]; then
+	verify_bin=$1
+else
+	verify_bin="`pwd`/x509_verify"
+	if [ -e ./x509_verify.exe ]; then
+		verify_bin="`pwd`/x509_verify.exe"
+	fi
+fi
+
+if [ $# -ge 2 ]; then
+	openssl_dir=`dirname "$2"`
+elif [ -d ../apps/openssl ]; then
+	openssl_dir="`pwd`/../apps/openssl"
+else
+	openssl_dir="`pwd`/../apps"
+fi
+
+PATH="$openssl_dir:$PATH"
+export PATH
+
+if [ -f "$openssl_conf" ]; then
+	OPENSSL_CONF="$openssl_conf"
+	export OPENSSL_CONF
+fi
+
+workdir=x509_verify-certs
+
+cleanup()
+{
+	rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+rm -rf "$workdir"
+mkdir "$workdir"
+
+perl "$make_dir_roots" "$certs_path" "$workdir"
+
+(
+	cd "$workdir"
+	"$verify_bin" "$certs_path"
+)

--- a/update.sh
+++ b/update.sh
@@ -334,10 +334,20 @@ touch tests/empty.c
 for i in `find $libcrypto_regress -name '*.[ch]'`; do
 	 $CP "$i" tests
 done
+# x509/verify.c collides with x509/bettertls/verify.c when flattened.
+$CP $libcrypto_regress/x509/verify.c tests/x509_verify.c
 $CP $libcrypto_regress/evp/evptests.txt tests
 $CP $libcrypto_regress/aead/*.txt tests
 $CP $libcrypto_regress/ct/ctlog.conf tests
 $CP $libcrypto_regress/ct/*.crt tests
+$CP $libcrypto_regress/x509/make-dir-roots.pl tests
+rm -rf tests/certs
+mkdir -p tests/certs
+for i in $libcrypto_regress/certs/[0-9]*; do
+	if [ -d "$i" ]; then
+		$CP -R "$i" tests/certs
+	fi
+done
 $CP $libcrypto_regress/x509/policy/*.pem tests
 $CP $libcrypto_regress/mlkem/*.txt tests
 


### PR DESCRIPTION
Copy regress/lib/libcrypto/x509/verify.c as x509_verify.c to avoid the basename collision with x509/bettertls/verify.c when regress tests are flattened into tests.

Also copy the libcrypto cert test data and make-dir-roots.pl, add a wrapper to prepare the CApath roots directory, and register the test for both autotools and CMake.

Refs #1273