### PR TITLE
nul-terminate the snprintf shim on pre-2015 msvc

### DIFF
--- a/include/compat/stdio.h
+++ b/include/compat/stdio.h
@@ -57,7 +57,25 @@ int posix_rename(const char *oldpath, const char *newpath);
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
+#include <stdarg.h>
+
+static inline int
+libressl_snprintf(char *str, size_t size, const char *format, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, format);
+	ret = _vsnprintf(str, size, format, ap);
+	va_end(ap);
+
+	/* _vsnprintf does not NUL-terminate when the output is truncated. */
+	if (size != 0)
+		str[size - 1] = '\0';
+
+	return ret;
+}
+#define snprintf libressl_snprintf
 #endif
 
 #endif


### PR DESCRIPTION
On pre-2015 MSVC (_MSC_VER < 1900) the shim aliases snprintf to _snprintf:
- _snprintf leaves the buffer unterminated when the output is truncated, unlike C99 snprintf
- code that formats untrusted data (cert fields, host names) into a fixed buffer then reads it back as a string runs off the end
- the wrapper forces termination and preserves the existing return value, so valid inputs behave the same
VS2015+ builds compile out this branch and are untouched.