### PR TITLE
fix htole64 fallback byte order in AIX endian shim

### DIFF
--- a/include/compat/endian.h
+++ b/include/compat/endian.h
@@ -182,15 +182,15 @@ static inline uint64_t htole64(uint64_t x) {
 		uint64_t u64;
 		unsigned char bytes[8];
 	} val;
-	val.u64 = x;
-	return ((uint64_t)val.bytes[0] << 56) |
-	((uint64_t)val.bytes[1] << 48) |
-	((uint64_t)val.bytes[2] << 40) |
-	((uint64_t)val.bytes[3] << 32) |
-	((uint64_t)val.bytes[4] << 24) |
-	((uint64_t)val.bytes[5] << 16) |
-	((uint64_t)val.bytes[6] << 8) |
-	(uint64_t)val.bytes[7];
+	val.bytes[0] = (unsigned char)x;
+	val.bytes[1] = (unsigned char)(x >> 8);
+	val.bytes[2] = (unsigned char)(x >> 16);
+	val.bytes[3] = (unsigned char)(x >> 24);
+	val.bytes[4] = (unsigned char)(x >> 32);
+	val.bytes[5] = (unsigned char)(x >> 40);
+	val.bytes[6] = (unsigned char)(x >> 48);
+	val.bytes[7] = (unsigned char)(x >> 56);
+	return val.u64;
 #endif
 }
 


### PR DESCRIPTION
htole64() in the AIX endian shim has a fallback path, taken when the compiler doesn't predefine __BYTE_ORDER__ (classic IBM xlc), that is byte order inverted:
- it loads the value's native bytes and reassembles them big-endian first, so on a big-endian host it returns the input unchanged instead of swapping
- that is the opposite of htole64, and disagrees with the sibling le64toh macro and the __BYTE_ORDER__ branch right above it
- crypto/sha/sha3.c stores and loads the Keccak state through htole64/le64toh, so SHA-3 and SHAKE output comes out byte-reversed per 64-bit lane on such a build

Build the little-endian byte layout in the union and read it back in host order, so the fallback holds on either endianness. Confined to the _AIX block, so other targets are untouched.