### PR TITLE
honor the requested timeout in the win32 poll shim

### DIFF
--- a/apps/openssl/compat/poll_win.c
+++ b/apps/openssl/compat/poll_win.c
@@ -264,6 +264,14 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 
 	do {
 		TIMEVAL tv;
+
+		/*
+		 * Cap the wait at the time remaining so the final pass
+		 * does not overshoot the requested timeout.
+		 */
+		if (timeout_ms != -1 && timeout_ms - timespent_ms < looptime_ms)
+			looptime_ms = timeout_ms - timespent_ms;
+
 		tv.tv_sec = 0;
 		tv.tv_usec = looptime_ms * 1000;
 		int handle_signaled = 0;

--- a/apps/openssl/compat/poll_win.c
+++ b/apps/openssl/compat/poll_win.c
@@ -166,6 +166,7 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 	 * select machinery
 	 */
 	fd_set rfds, wfds, efds;
+	fd_set rfds_in, wfds_in, efds_in;
 	int rc;
 	int num_sockets;
 
@@ -250,11 +251,26 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 
 	looptime_ms = (timeout_ms > 100 || timeout_ms == -1) ? 100 : timeout_ms;
 
+	/*
+	 * select() clears every descriptor that is not ready from the
+	 * fd_sets, so a pass that times out leaves them empty. Keep a
+	 * pristine copy and restore it before each select(), otherwise the
+	 * next pass hands select() three empty sets and Windows fails it with
+	 * WSAEINVAL instead of waiting out the remaining timeout.
+	 */
+	rfds_in = rfds;
+	wfds_in = wfds;
+	efds_in = efds;
+
 	do {
 		TIMEVAL tv;
 		tv.tv_sec = 0;
 		tv.tv_usec = looptime_ms * 1000;
 		int handle_signaled = 0;
+
+		rfds = rfds_in;
+		wfds = wfds_in;
+		efds = efds_in;
 
 		/*
 		 * Check if any file handles have signaled

--- a/apps/openssl/compat/poll_win.c
+++ b/apps/openssl/compat/poll_win.c
@@ -249,8 +249,6 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 	wait_rc = WAIT_FAILED;
 
 	looptime_ms = (timeout_ms > 100 || timeout_ms == -1) ? 100 : timeout_ms;
-	if (timeout_ms == -1)
-		timeout_ms = INFINITE;
 
 	do {
 		TIMEVAL tv;
@@ -280,7 +278,7 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 		/*
 		 * If we signaled on a file handle, don't wait on the sockets.
 		 */
-		if (wait_rc >= WAIT_OBJECT_0 &&
+		if (num_handles && wait_rc >= WAIT_OBJECT_0 &&
 		    (wait_rc <= WAIT_OBJECT_0 + num_handles - 1)) {
 			tv.tv_usec = 0;
 			handle_signaled = 1;
@@ -298,7 +296,7 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 
 		timespent_ms += looptime_ms;
 
-	} while (timespent_ms < timeout_ms);
+	} while (timeout_ms == -1 || timespent_ms < timeout_ms);
 
 	rc = 0;
 	num_handles = 0;


### PR DESCRIPTION
poll() on Windows never waits the full timeout, from two spots in the wait loop:
- an infinite wait (timeout -1) assigns timeout_ms = INFINITE, but timeout_ms is int so it truncates back to -1 and the `timespent_ms < timeout_ms` guard exits after the first ~100ms pass
- a socket-only set leaves num_handles 0, so `WAIT_OBJECT_0 + num_handles - 1` underflows to 0xFFFFFFFF and the stale WAIT_FAILED reads as a signaled handle, breaking on the first iteration

Either way an idle blocking poll returns 0, so s_client/s_server spin instead of waiting.