### PR TITLE
restore file offset on error in pread/pwrite shims

### DIFF
--- a/tls/compat/pread.c
+++ b/tls/compat/pread.c
@@ -8,21 +8,25 @@
 
 #define NO_REDEF_POSIX_FUNCTIONS
 
+#include <errno.h>
 #include <unistd.h>
 
 ssize_t
 pread(int d, void *buf, size_t nbytes, off_t offset)
 {
-	off_t cpos, opos, rpos;
+	off_t cpos;
 	ssize_t bytes;
+	int save_errno;
+
 	if((cpos = lseek(d, 0, SEEK_CUR)) == -1)
 		return -1;
-	if((opos = lseek(d, offset, SEEK_SET)) == -1)
+	if(lseek(d, offset, SEEK_SET) == -1)
 		return -1;
-	if((bytes = read(d, buf, nbytes)) == -1)
+	bytes = read(d, buf, nbytes);
+	save_errno = errno;
+	if(lseek(d, cpos, SEEK_SET) == -1)
 		return -1;
-	if((rpos = lseek(d, cpos, SEEK_SET)) == -1)
-		return -1;
+	errno = save_errno;
 	return bytes;
 }
 

--- a/tls/compat/pwrite.c
+++ b/tls/compat/pwrite.c
@@ -8,21 +8,25 @@
 
 #define NO_REDEF_POSIX_FUNCTIONS
 
+#include <errno.h>
 #include <unistd.h>
 
 ssize_t
 pwrite(int d, const void *buf, size_t nbytes, off_t offset)
 {
-	off_t cpos, opos, rpos;
+	off_t cpos;
 	ssize_t bytes;
+	int save_errno;
+
 	if((cpos = lseek(d, 0, SEEK_CUR)) == -1)
 		return -1;
-	if((opos = lseek(d, offset, SEEK_SET)) == -1)
+	if(lseek(d, offset, SEEK_SET) == -1)
 		return -1;
-	if((bytes = write(d, buf, nbytes)) == -1)
+	bytes = write(d, buf, nbytes);
+	save_errno = errno;
+	if(lseek(d, cpos, SEEK_SET) == -1)
 		return -1;
-	if((rpos = lseek(d, cpos, SEEK_SET)) == -1)
-		return -1;
+	errno = save_errno;
 	return bytes;
 }
 


### PR DESCRIPTION
The win32/mingw pread and pwrite shims (tls/compat) emulate the POSIX calls by saving the current offset, seeking to the target, doing the I/O, then seeking back. POSIX requires both to leave the file offset unchanged. On the I/O-error path that contract is broken:

- when read()/write() returns -1 the function returns immediately, so the seek back to the caller's saved position never runs and the descriptor is left positioned at the pread/pwrite target
- pwrite carries the same defect
- a following read/write on that descriptor then runs at the wrong offset

Save the position once, restore it after the I/O on every path, and keep the read/write errno across the restoring lseek.