### PR TITLE
honor SOCK_NONBLOCK in the accept4 shim

### DIFF
--- a/apps/nc/compat/accept4.c
+++ b/apps/nc/compat/accept4.c
@@ -5,12 +5,18 @@ int
 accept4(int s, struct sockaddr *addr, socklen_t *addrlen, int flags)
 {
 	int rets = accept(s, addr, addrlen);
+	int fl;
 	if (rets == -1)
 		return rets;
 
 	if (flags & SOCK_CLOEXEC) {
-		flags = fcntl(rets, F_GETFD);
-		fcntl(rets, F_SETFD, flags | FD_CLOEXEC);
+		fl = fcntl(rets, F_GETFD);
+		fcntl(rets, F_SETFD, fl | FD_CLOEXEC);
+	}
+
+	if (flags & SOCK_NONBLOCK) {
+		fl = fcntl(rets, F_GETFL);
+		fcntl(rets, F_SETFL, fl | O_NONBLOCK);
 	}
 
 	return rets;


### PR DESCRIPTION
accept4() emulation applies SOCK_CLOEXEC but drops SOCK_NONBLOCK, so accepted sockets come back blocking:
- only the CLOEXEC branch runs; the SOCK_NONBLOCK bit never becomes O_NONBLOCK
- nc's listener calls accept4(s, ..., SOCK_NONBLOCK) and hands the fd to the poll() loop in readwrite(), which assumes non-blocking I/O
- the sibling socket() shim in compat/socket.c already sets both flags
Set O_NONBLOCK when SOCK_NONBLOCK is requested so the accepted fd matches the requested mode.