### PR TITLE
set errno for unmapped codes in wsa_errno and wsa_select_errno

### DIFF
--- a/apps/openssl/compat/poll_win.c
+++ b/apps/openssl/compat/poll_win.c
@@ -152,6 +152,9 @@ wsa_select_errno(int err)
 	case WSAENETDOWN:
 		errno = ENOMEM;
 		break;
+	default:
+		errno = EIO;
+		break;
 	}
 	return -1;
 }

--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -178,6 +178,9 @@ wsa_errno(int err)
 	case WSAETIMEDOUT:
 		errno = EPIPE;
 		break;
+	default:
+		errno = EIO;
+		break;
 	}
 	return -1;
 }


### PR DESCRIPTION
Two winsock-to-errno helpers fall through without setting errno for codes they don't list:
- wsa_errno (posix_win.c): posix_read/write/connect/close/getsockopt return -1 but leave errno at a stale value for common codes like WSAEADDRINUSE and WSAENETUNREACH
- wsa_select_errno (poll_win.c): poll() has the same gap when select() fails with an unlisted code such as WSAENOTSOCK
Added a default to both switches setting EIO, matching the WSAENETDOWN mapping wsa_errno already uses.
