### PR TITLE
Run x509_verify only when perl is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ include(cmake_export_symbol)
 include(GNUInstallDirs)
 
 enable_testing()
+find_program(PERL_EXECUTABLE perl perl5)
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/ssl/VERSION SSL_VERSION)
 string(STRIP ${SSL_VERSION} SSL_VERSION)

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,9 @@ AC_PROG_CC([cc gcc])
 AM_PROG_CC_C_O
 LT_INIT([pic-only])
 
+AC_CHECK_PROGS([PERL], [perl perl5])
+AM_CONDITIONAL([HAVE_PERL], [test "x$PERL" != x])
+
 CHECK_OS_OPTIONS
 
 CHECK_C_HARDENING_OPTIONS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -935,11 +935,11 @@ add_platform_test(valid_handshakes_terminate valid_handshakes_terminate)
 add_executable(x509_verify x509_verify.c)
 target_link_libraries(x509_verify ${OPENSSL_TEST_LIBS})
 add_dependencies(x509_verify openssl)
-if(NOT WIN32 AND NOT EMSCRIPTEN)
+if(NOT WIN32 AND NOT EMSCRIPTEN AND PERL_EXECUTABLE)
 	add_test(NAME x509_verify COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/x509_verify.sh
 	    $<TARGET_FILE:x509_verify> $<TARGET_FILE:openssl>)
 	set_tests_properties(x509_verify PROPERTIES
-	    ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}"
+	    ENVIRONMENT "srcdir=${TEST_SOURCE_DIR};PERL=${PERL_EXECUTABLE}"
 	    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 	# This test depends on certificate times that can exceed 32-bit time_t
 	# range, so match the existing time tests and expect failure there.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -94,6 +94,7 @@ libtest_la_SOURCES = empty.c
 
 LDADD = libtest.la $(PLATFORM_LDADD) $(PROG_LDADD)
 
+TESTS_ENVIRONMENT = PERL='$(PERL)'
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 
 TESTS =
@@ -919,6 +920,7 @@ check_PROGRAMS += valid_handshakes_terminate
 valid_handshakes_terminate_SOURCES = valid_handshakes_terminate.c
 
 # x509_verify
+if HAVE_PERL
 # This test depends on certificate times that can exceed 32-bit time_t
 # range, so match the existing time tests and expect failure there.
 if SMALL_TIME_T
@@ -926,6 +928,7 @@ XFAIL_TESTS += x509_verify.sh
 endif
 TESTS += x509_verify.sh
 check_PROGRAMS += x509_verify
+endif
 x509_verify_SOURCES = x509_verify.c
 EXTRA_DIST += x509_verify.sh
 EXTRA_DIST += make-dir-roots.pl

--- a/tests/x509_verify.sh
+++ b/tests/x509_verify.sh
@@ -20,6 +20,10 @@ if [ -z "$srcdir" ]; then
 	srcdir=.
 fi
 
+if [ -z "$PERL" ]; then
+	PERL=perl
+fi
+
 case "$srcdir" in
 /*)
 	certs_path="$srcdir/certs"
@@ -69,7 +73,7 @@ trap cleanup EXIT
 rm -rf "$workdir"
 mkdir "$workdir"
 
-perl "$make_dir_roots" "$certs_path" "$workdir"
+"$PERL" "$make_dir_roots" "$certs_path" "$workdir"
 
 (
 	cd "$workdir"


### PR DESCRIPTION
The x509_verify wrapper uses make-dir-roots.pl to prepare the hashed CApath roots directory.  This introduced a perl dependency for running the test suite from release tarballs.

Detect perl during configure and CMake configuration, and only register x509_verify when perl is available.

Ref https://github.com/libressl/portable/pull/1317#issuecomment-5010022518