### PR TITLE
Install perl in FreeBSD cmake CI

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -63,7 +63,7 @@ jobs:
           release: "${{ env.FREEBSD_VERSION }}"
           copyback: false
           prepare: |
-            pkg install -y cmake ninja
+            pkg install -y cmake ninja perl5
           run: |
             export CTEST_OUTPUT_ON_FAILURE=1
             cmake -G Ninja -B build


### PR DESCRIPTION
Install perl5 in the FreeBSD cmake jobs.

Ref https://github.com/libressl/portable/pull/1317#issuecomment-5010022518 and https://github.com/libressl/portable/pull/1325