### PR TITLE
Run bn_mul_div test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -283,6 +283,13 @@ add_executable(bn_mont bn_mont.c)
 target_link_libraries(bn_mont ${OPENSSL_TEST_LIBS})
 add_platform_test(bn_mont bn_mont)
 
+# bn_mul_div
+if(NOT (WIN32 OR EMSCRIPTEN))
+	add_executable(bn_mul_div bn_mul_div.c)
+	target_link_libraries(bn_mul_div ${OPENSSL_TEST_LIBS})
+	add_platform_test(bn_mul_div bn_mul_div)
+endif()
+
 # bn_primes
 add_executable(bn_primes bn_primes.c)
 target_link_libraries(bn_primes ${OPENSSL_TEST_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -307,6 +307,13 @@ TESTS += bn_mont
 check_PROGRAMS += bn_mont
 bn_mont_SOURCES = bn_mont.c
 
+# bn_mul_div
+if !HOST_WIN
+TESTS += bn_mul_div
+check_PROGRAMS += bn_mul_div
+bn_mul_div_SOURCES = bn_mul_div.c
+endif
+
 # bn_primes
 TESTS += bn_primes
 check_PROGRAMS += bn_primes


### PR DESCRIPTION
Although it contains benchmark code used with `--benchmark`, its normal execution path runs `BN_sqr()` regression checks.