### PR TITLE
Run libssl tlstest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -835,6 +835,15 @@ add_executable(ssl_versions ssl_versions.c)
 target_link_libraries(ssl_versions ${OPENSSL_TEST_LIBS})
 add_platform_test(ssl_versions ssl_versions)
 
+# ssl_tlstest
+add_executable(ssl_tlstest ssl_tlstest.c)
+target_link_libraries(ssl_tlstest ${OPENSSL_TEST_LIBS})
+prepare_emscripten_test_target(ssl_tlstest)
+add_platform_test(ssl_tlstest $<TARGET_FILE:ssl_tlstest>
+    ${CMAKE_CURRENT_SOURCE_DIR}/server1-rsa.pem
+    ${CMAKE_CURRENT_SOURCE_DIR}/server1-rsa-chain.pem
+    ${CMAKE_CURRENT_SOURCE_DIR}/ca-root-rsa.pem)
+
 # ssltest
 add_executable(ssltest ssltest.c)
 target_link_libraries(ssltest ${OPENSSL_TEST_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -844,6 +844,12 @@ TESTS += ssl_versions
 check_PROGRAMS += ssl_versions
 ssl_versions_SOURCES = ssl_versions.c
 
+# ssl_tlstest
+TESTS += ssl_tlstest.sh
+check_PROGRAMS += ssl_tlstest
+ssl_tlstest_SOURCES = ssl_tlstest.c
+EXTRA_DIST += ssl_tlstest.sh
+
 # ssltest
 TESTS += ssltest.sh
 check_PROGRAMS += ssltest

--- a/tests/ssl_tlstest.sh
+++ b/tests/ssl_tlstest.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Kenjiro Nakayama
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -e
+
+if [ $# -ge 1 ]; then
+	ssl_tlstest_bin=$1
+else
+	ssl_tlstest_bin=./ssl_tlstest
+	if [ -e ./ssl_tlstest.exe ]; then
+		ssl_tlstest_bin=./ssl_tlstest.exe
+	elif [ -e ./ssl_tlstest.js ]; then
+		ssl_tlstest_bin=./ssl_tlstest.js
+	fi
+fi
+
+if [ -z "$srcdir" ]; then
+	srcdir=.
+fi
+
+case "$ssl_tlstest_bin" in
+*.js)
+	node "$ssl_tlstest_bin" "$srcdir/server1-rsa.pem" \
+	    "$srcdir/server1-rsa-chain.pem" "$srcdir/ca-root-rsa.pem"
+	;;
+*)
+	"$ssl_tlstest_bin" "$srcdir/server1-rsa.pem" \
+	    "$srcdir/server1-rsa-chain.pem" "$srcdir/ca-root-rsa.pem"
+	;;
+esac

--- a/update.sh
+++ b/update.sh
@@ -369,6 +369,8 @@ $CP $libssl_regress/ssl/testssl tests
 for i in `find $libssl_regress -name '*.c'`; do
 	 $CP "$i" tests
 done
+# tls/tlstest.c collides with libtls/tls/tlstest.c when flattened.
+$CP $libssl_regress/tls/tlstest.c tests/ssl_tlstest.c
 $CP $libssl_regress/unit/tests.h tests
 $CP $libssl_regress/certs/*.pem tests
 $CP $libssl_regress/certs/*.crl tests


### PR DESCRIPTION
regress/lib/libssl/tls/tlstest.c and regress/lib/libtls/tls/tlstest.c have the same file name, so the flattened test copy only kept the libtls test.

Copy the libssl test as ssl_tlstest.c, also add a wrapper script.

Ref #1273