### PR TITLE
use raw CRT open/close in win32 socketpair sentinel

### DIFF
--- a/tests/compat/pipe2.c
+++ b/tests/compat/pipe2.c
@@ -38,16 +38,20 @@ static int setfl(int fd, int flag)
 /*
  * Have open() temporarily use up file descriptors until reaching beyond the
  * allocated sockets, then leak the ones conflicting with any of the latter.
+ *
+ * open()/close() are redefined to posix_open()/posix_close() in this file,
+ * which tag descriptors with the 0x80000000 bit. Use the raw CRT _open/_close
+ * so the values compare against the socket handles in the same namespace.
  */
 static void create_issue_1069_sentinels(int socket_vector[2])
 {
-	int fd = open("CONIN$", O_RDONLY);
+	int fd = _open("CONIN$", O_RDONLY);
 	if (fd == -1 || (fd > socket_vector[0] && fd > socket_vector[1])) {
 		return;
 	}
 	create_issue_1069_sentinels(socket_vector);
 	if (fd != socket_vector[0] && fd != socket_vector[1]) {
-		close(fd);
+		_close(fd);
 	}
 }
 


### PR DESCRIPTION
The issue #1069 descriptor-reservation sentinel in the win32 socketpair never reserves anything:
- open()/close() here resolve to posix_open()/posix_close() (win32netcompat.h), which tag every descriptor with the 0x80000000 bit
- fd is then negative, so `fd > socket_vector[i]` is always false and the loop recurses opening CONIN$ until the CRT descriptor table is exhausted, closing everything on unwind
- `fd == socket_vector[i]` never matches, so no colliding descriptor is leaked and the mitigation is a no-op
- the raw CRT _open/_close keep the sentinel in the same descriptor namespace as the socket handles