### PR TITLE
disable bn_mul_div test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -283,13 +283,14 @@ add_executable(bn_mont bn_mont.c)
 target_link_libraries(bn_mont ${OPENSSL_TEST_LIBS})
 add_platform_test(bn_mont bn_mont)
 
-# bn_mul_div
-# The benchmark code uses TIMEVAL_TO_TIMESPEC, which is unavailable on Solaris.
-if(NOT (WIN32 OR EMSCRIPTEN OR SOLARIS))
-	add_executable(bn_mul_div bn_mul_div.c)
-	target_link_libraries(bn_mul_div ${OPENSSL_TEST_LIBS})
-	add_platform_test(bn_mul_div bn_mul_div)
-endif()
+# bn_mul_div is mostly benchmark code with non-standard timing dependencies,
+# while the non-benchmark test coverage is not worth the cross-platform fallout.
+# # bn_mul_div
+# if(NOT (WIN32 OR EMSCRIPTEN OR SOLARIS))
+# 	add_executable(bn_mul_div bn_mul_div.c)
+# 	target_link_libraries(bn_mul_div ${OPENSSL_TEST_LIBS})
+# 	add_platform_test(bn_mul_div bn_mul_div)
+# endif()
 
 # bn_primes
 add_executable(bn_primes bn_primes.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -307,15 +307,16 @@ TESTS += bn_mont
 check_PROGRAMS += bn_mont
 bn_mont_SOURCES = bn_mont.c
 
-# bn_mul_div
-# The benchmark code uses TIMEVAL_TO_TIMESPEC, which is unavailable on Solaris.
-if !HOST_WIN
-if !HOST_SOLARIS
-TESTS += bn_mul_div
-check_PROGRAMS += bn_mul_div
-bn_mul_div_SOURCES = bn_mul_div.c
-endif
-endif
+# bn_mul_div is mostly benchmark code with non-standard timing dependencies,
+# while the non-benchmark test coverage is not worth the cross-platform fallout.
+## bn_mul_div
+#if !HOST_WIN
+#if !HOST_SOLARIS
+#TESTS += bn_mul_div
+#check_PROGRAMS += bn_mul_div
+#bn_mul_div_SOURCES = bn_mul_div.c
+#endif
+#endif
 
 # bn_primes
 TESTS += bn_primes


### PR DESCRIPTION
`bn_mul_div` is mostly benchmark code and depends on non-portable timing interfaces such as `TIMEVAL_TO_TIMESPEC`. While its normal execution path only tests squaring 0, 1, and 2, the benchmark code is still compiled and causes portability issues on some platforms.

Ref https://github.com/libressl/portable/pull/1332#pullrequestreview-4742275786