### PR TITLE
release CRYPTO_LOCK_UI on open_console error paths

### DIFF
--- a/crypto/compat/ui_openssl_win.c
+++ b/crypto/compat/ui_openssl_win.c
@@ -287,11 +287,15 @@ open_console(UI *ui)
 
 	HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
 	if (handle != NULL && handle != INVALID_HANDLE_VALUE) {
-		if (GetFileType(handle) == FILE_TYPE_CHAR)
-			return GetConsoleMode(handle, &console_mode);
-		else
+		if (GetFileType(handle) == FILE_TYPE_CHAR) {
+			if (GetConsoleMode(handle, &console_mode))
+				return 1;
+		} else
 			return 1;
 	}
+
+	/* UI_process() skips the close callback when open fails; unlock here. */
+	CRYPTO_w_unlock(CRYPTO_LOCK_UI);
 	return 0;
 }
 


### PR DESCRIPTION
open_console() takes CRYPTO_LOCK_UI, then returns failure on two paths without releasing it:
- GetStdHandle(STD_INPUT_HANDLE) returns NULL (services, GUI apps, detached processes with no console)
- stdin is a char device but GetConsoleMode() fails
- UI_process() returns -1 when the open-session callback fails and never calls close_console, the only unlock, so the lock stays held and later passphrase prompts from other threads block on EnterCriticalSection

Drop the lock on those paths; the success paths still hand it to close_console, so return values are unchanged.