### PR TITLE
error out when nc minttl is unsupported in set_common_sockopts

### DIFF
--- a/patches/netcat.c.patch
+++ b/patches/netcat.c.patch
@@ -131,7 +131,7 @@
  	}
  	if (Iflag) {
  		if (setsockopt(s, SOL_SOCKET, SO_RCVBUF,
-@@ -1612,13 +1641,17 @@ set_common_sockopts(int s, int af)
+@@ -1612,13 +1641,27 @@ set_common_sockopts(int s, int af)
  	}
  
  	if (minttl != -1) {
@@ -139,6 +139,11 @@
  		if (af == AF_INET && setsockopt(s, IPPROTO_IP,
  		    IP_MINTTL, &minttl, sizeof(minttl)))
  			err(1, "set IP min TTL");
++#else
++		if (af == AF_INET) {
++			errno = ENOPROTOOPT;
++			err(1, "set IP min TTL not supported");
++		}
 +#endif
  
 -		else if (af == AF_INET6 && setsockopt(s, IPPROTO_IPV6,
@@ -146,11 +151,16 @@
 +		if (af == AF_INET6 && setsockopt(s, IPPROTO_IPV6,
  		    IPV6_MINHOPCOUNT, &minttl, sizeof(minttl)))
  			err(1, "set IPv6 min hop count");
++#else
++		if (af == AF_INET6) {
++			errno = ENOPROTOOPT;
++			err(1, "set IPv6 min hop count not supported");
++		}
 +#endif
  	}
  }
  
-@@ -1849,15 +1882,19 @@ help(void)
+@@ -1849,15 +1892,19 @@ help(void)
  	\t-P proxyuser\tUsername for proxy authentication\n\
  	\t-p port\t	Specify local port for remote connects\n\
  	\t-R CAfile	CA bundle\n\

--- a/patches/netcat.c.patch
+++ b/patches/netcat.c.patch
@@ -131,7 +131,7 @@
  	}
  	if (Iflag) {
  		if (setsockopt(s, SOL_SOCKET, SO_RCVBUF,
-@@ -1612,13 +1641,27 @@ set_common_sockopts(int s, int af)
+@@ -1612,13 +1641,23 @@ set_common_sockopts(int s, int af)
  	}
  
  	if (minttl != -1) {
@@ -140,10 +140,8 @@
  		    IP_MINTTL, &minttl, sizeof(minttl)))
  			err(1, "set IP min TTL");
 +#else
-+		if (af == AF_INET) {
-+			errno = ENOPROTOOPT;
-+			err(1, "set IP min TTL not supported");
-+		}
++		if (af == AF_INET)
++			errx(1, "set IP min TTL not supported");
 +#endif
  
 -		else if (af == AF_INET6 && setsockopt(s, IPPROTO_IPV6,
@@ -152,15 +150,13 @@
  		    IPV6_MINHOPCOUNT, &minttl, sizeof(minttl)))
  			err(1, "set IPv6 min hop count");
 +#else
-+		if (af == AF_INET6) {
-+			errno = ENOPROTOOPT;
-+			err(1, "set IPv6 min hop count not supported");
-+		}
++		if (af == AF_INET6)
++			errx(1, "set IPv6 min hop count not supported");
 +#endif
  	}
  }
  
-@@ -1849,15 +1892,19 @@ help(void)
+@@ -1849,15 +1888,19 @@ help(void)
  	\t-P proxyuser\tUsername for proxy authentication\n\
  	\t-p port\t	Specify local port for remote connects\n\
  	\t-R CAfile	CA bundle\n\


### PR DESCRIPTION
nc takes -m minttl on every platform, but set_common_sockopts only enforces it where the socket option exists:
- IP_MINTTL is not defined on macOS, so the IPv4 branch is preprocessed away and -m becomes a no-op
- IPV6_MINHOPCOUNT is missing there too, so the IPv6 branch goes the same way and the whole "if (minttl != -1)" body ends up empty
- the IPV6_TCLASS case a few lines up already reports ENOPROTOOPT, and -S and -V reach usage(1) because their getopt cases are compiled out, so minttl was the one requested option still being dropped without a word

Gave it the same treatment as IPV6_TCLASS. On macOS, nc -m 255 now exits with "set IP min TTL not supported: Protocol not available" rather than running with no hop-limit filter on the socket.
