### PR TITLE
set close-on-exec on the tty descriptor in readpassphrase

### DIFF
--- a/apps/nc/compat/readpassphrase.c
+++ b/apps/nc/compat/readpassphrase.c
@@ -94,6 +94,8 @@ restart:
 		}
 		input = STDIN_FILENO;
 		output = STDERR_FILENO;
+	} else {
+		(void)fcntl(input, F_SETFD, FD_CLOEXEC);
 	}
 
 	/*


### PR DESCRIPTION
1. readpassphrase() opens _PATH_TTY read/write and nothing marks that descriptor close-on-exec, so it survives into anything the caller exec()s while the prompt is up.
2. Only the /dev/tty branch is affected; the RPP_STDIN and open-failure paths fall back to STDIN_FILENO and must be left alone.

Setting FD_CLOEXEC after the open rather than passing O_CLOEXEC keeps this correct on targets where compat/fcntl.h only fakes the flag, and matches compat/accept4.c and compat/socket.c; OpenBSD's own copy uses O_CLOEXEC on the open.