### PR TITLE
hook up the x509 callback tests 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -342,8 +342,30 @@ add_executable(bytestringtest bytestringtest.c)
 target_link_libraries(bytestringtest ${OPENSSL_TEST_LIBS})
 add_platform_test(bytestringtest bytestringtest)
 
-# callback
-# callbackfailures
+# x509_callbacks
+add_executable(callback callback.c)
+target_link_libraries(callback ${OPENSSL_TEST_LIBS})
+add_executable(callbackfailures callbackfailures.c)
+target_link_libraries(callbackfailures ${OPENSSL_TEST_LIBS})
+add_executable(expirecallback expirecallback.c)
+target_link_libraries(expirecallback ${OPENSSL_TEST_LIBS})
+add_dependencies(callback openssl)
+if(NOT WIN32 AND NOT EMSCRIPTEN AND PERL_EXECUTABLE)
+	add_test(NAME x509_callbacks COMMAND
+	    ${CMAKE_CURRENT_SOURCE_DIR}/x509_callbacks.sh
+	    $<TARGET_FILE:callback>
+	    $<TARGET_FILE:callbackfailures>
+	    $<TARGET_FILE:expirecallback>
+	    $<TARGET_FILE:openssl>)
+	set_tests_properties(x509_callbacks PROPERTIES
+	    ENVIRONMENT "srcdir=${TEST_SOURCE_DIR};PERL=${PERL_EXECUTABLE}"
+	    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+	# These tests use the same certificate corpus as x509_verify and can
+	# exceed the range of a 32-bit time_t.
+	if(SMALL_TIME_T)
+		set_property(TEST x509_callbacks PROPERTY WILL_FAIL TRUE)
+	endif()
+endif()
 
 # casttest
 add_executable(casttest casttest.c)
@@ -502,8 +524,6 @@ add_platform_test(evp_test evp_test)
 add_executable(exdata_test exdata_test.c)
 target_link_libraries(exdata_test ${OPENSSL_TEST_LIBS})
 add_platform_test(exdata_test exdata_test)
-
-# expirecallback.c
 
 # explicit_bzero
 # SA_ONSTACK is unavailable on Windows, sigsuspend is unavailable on Emscripten

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -105,6 +105,7 @@ DISTCLEANFILES = pidwraptest.txt
 
 distclean-local:
 	rm -rf ssl_verify-certs
+	rm -rf x509_callback-certs
 	rm -rf x509_verify-certs
 
 # XXX - should probably be in their own static lib
@@ -365,8 +366,21 @@ TESTS += bytestringtest
 check_PROGRAMS += bytestringtest
 bytestringtest_SOURCES = bytestringtest.c
 
-# callback
-# callbackfailures
+# x509_callbacks
+if HAVE_PERL
+# These tests use the same certificate corpus as x509_verify and can exceed
+# the range of a 32-bit time_t.
+if SMALL_TIME_T
+XFAIL_TESTS += x509_callbacks.sh
+endif
+TESTS += x509_callbacks.sh
+check_PROGRAMS += callback callbackfailures expirecallback
+endif
+callback_SOURCES = callback.c
+callbackfailures_SOURCES = callbackfailures.c
+expirecallback_SOURCES = expirecallback.c
+EXTRA_DIST += x509_callbacks.sh
+EXTRA_DIST += callback.pl
 
 # casttest
 TESTS += casttest
@@ -523,8 +537,6 @@ evp_test_SOURCES = evp_test.c
 TESTS += exdata_test
 check_PROGRAMS += exdata_test
 exdata_test_SOURCES = exdata_test.c
-
-# expirecallback.c
 
 # explicit_bzero
 # explicit_bzero relies on SA_ONSTACK, which is unavailable on Windows

--- a/tests/x509_callbacks.sh
+++ b/tests/x509_callbacks.sh
@@ -27,12 +27,14 @@ fi
 case "$srcdir" in
 /*)
 	certs_path="$srcdir/certs"
+	ca_file="$srcdir/../cert.pem"
 	callback_check="$srcdir/callback.pl"
 	make_dir_roots="$srcdir/make-dir-roots.pl"
 	openssl_conf="$srcdir/openssl.cnf"
 	;;
 *)
 	certs_path="`pwd`/$srcdir/certs"
+	ca_file="`pwd`/$srcdir/../cert.pem"
 	callback_check="`pwd`/$srcdir/callback.pl"
 	make_dir_roots="`pwd`/$srcdir/make-dir-roots.pl"
 	openssl_conf="`pwd`/$srcdir/openssl.cnf"
@@ -87,6 +89,6 @@ mkdir "$workdir"
 	cd "$workdir"
 	"$callback_bin" "$certs_path"
 	"$PERL" "$callback_check" callback.out
-	"$callbackfailures_bin" "$certs_path"
+	"$callbackfailures_bin" "$certs_path" "$ca_file"
 	"$expirecallback_bin" "$certs_path"
 )

--- a/tests/x509_callbacks.sh
+++ b/tests/x509_callbacks.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Kenjiro Nakayama
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -e
+
+if [ -z "$srcdir" ]; then
+	srcdir=.
+fi
+
+if [ -z "$PERL" ]; then
+	PERL=perl
+fi
+
+case "$srcdir" in
+/*)
+	certs_path="$srcdir/certs"
+	callback_check="$srcdir/callback.pl"
+	make_dir_roots="$srcdir/make-dir-roots.pl"
+	openssl_conf="$srcdir/openssl.cnf"
+	;;
+*)
+	certs_path="`pwd`/$srcdir/certs"
+	callback_check="`pwd`/$srcdir/callback.pl"
+	make_dir_roots="`pwd`/$srcdir/make-dir-roots.pl"
+	openssl_conf="`pwd`/$srcdir/openssl.cnf"
+	;;
+esac
+
+if [ $# -ge 3 ]; then
+	callback_bin=$1
+	callbackfailures_bin=$2
+	expirecallback_bin=$3
+else
+	callback_bin="`pwd`/callback"
+	callbackfailures_bin="`pwd`/callbackfailures"
+	expirecallback_bin="`pwd`/expirecallback"
+	if [ -e ./callback.exe ]; then
+		callback_bin="`pwd`/callback.exe"
+		callbackfailures_bin="`pwd`/callbackfailures.exe"
+		expirecallback_bin="`pwd`/expirecallback.exe"
+	fi
+fi
+
+if [ $# -ge 4 ]; then
+	openssl_dir=`dirname "$4"`
+elif [ -d ../apps/openssl ]; then
+	openssl_dir="`pwd`/../apps/openssl"
+else
+	openssl_dir="`pwd`/../apps"
+fi
+
+PATH="$openssl_dir:$PATH"
+export PATH
+
+if [ -f "$openssl_conf" ]; then
+	OPENSSL_CONF="$openssl_conf"
+	export OPENSSL_CONF
+fi
+
+workdir=x509_callback-certs
+
+cleanup()
+{
+	rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+rm -rf "$workdir"
+mkdir "$workdir"
+
+"$PERL" "$make_dir_roots" "$certs_path" "$workdir"
+
+(
+	cd "$workdir"
+	"$callback_bin" "$certs_path"
+	"$PERL" "$callback_check" callback.out
+	"$callbackfailures_bin" "$certs_path"
+	"$expirecallback_bin" "$certs_path"
+)

--- a/update.sh
+++ b/update.sh
@@ -342,6 +342,7 @@ $CP $libcrypto_regress/evp/evptests.txt tests
 $CP $libcrypto_regress/aead/*.txt tests
 $CP $libcrypto_regress/ct/ctlog.conf tests
 $CP $libcrypto_regress/ct/*.crt tests
+$CP $libcrypto_regress/x509/callback.pl tests
 $CP $libcrypto_regress/x509/make-dir-roots.pl tests
 rm -rf tests/certs
 mkdir -p tests/certs


### PR DESCRIPTION
Copy callback.pl and add a wrapper that prepares the hashed roots
directory and checks the callback output.

Register callback, callbackfailures, and expirecallback with both
autotools and CMake.