### PR TITLE
don't override pledge and unveil when the host provides them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,16 @@ if(HAVE_GETPROGNAME)
 	add_definitions(-DHAVE_GETPROGNAME)
 endif()
 
+check_symbol_exists(pledge "unistd.h" HAVE_PLEDGE)
+if(HAVE_PLEDGE)
+	add_definitions(-DHAVE_PLEDGE)
+endif()
+
+check_symbol_exists(unveil "unistd.h" HAVE_UNVEIL)
+if(HAVE_UNVEIL)
+	add_definitions(-DHAVE_UNVEIL)
+endif()
+
 check_symbol_exists(syslog_r "syslog.h;stdarg.h" HAVE_SYSLOG_R)
 if(HAVE_SYSLOG_R)
 	add_definitions(-DHAVE_SYSLOG_R)

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -75,8 +75,13 @@ int getentropy(void *buf, size_t buflen);
 int getpagesize(void);
 #endif
 
+#ifndef HAVE_PLEDGE
 #define pledge(request, paths) 0
+#endif
+
+#ifndef HAVE_UNVEIL
 #define unveil(path, permissions) 0
+#endif
 
 #ifndef HAVE_PIPE2
 int pipe2(int fildes[2], int flags);

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -61,7 +61,7 @@ AM_CONDITIONAL([HAVE_SYSLOG_R], [test "x$ac_cv_func_syslog_r" = xyes])
 ])
 
 AC_DEFUN([CHECK_SYSCALL_COMPAT], [
-AC_CHECK_FUNCS([accept4 pipe2 pledge poll socketpair])
+AC_CHECK_FUNCS([accept4 pipe2 pledge poll socketpair unveil])
 AM_CONDITIONAL([HAVE_ACCEPT4], [test "x$ac_cv_func_accept4" = xyes])
 AM_CONDITIONAL([HAVE_PIPE2], [test "x$ac_cv_func_pipe2" = xyes])
 AM_CONDITIONAL([HAVE_PLEDGE], [test "x$ac_cv_func_pledge" = xyes])


### PR DESCRIPTION
1. include/compat/unistd.h defines pledge() and unveil() as no-op macros with no guard, so on a host that has them the macro shadows the real declaration #include_next just brought in.
2. every call site in openssl(1), nc(1) and ocspcheck(1) then expands to the constant 0 and the == -1 checks pass, so those programs run unconfined with nothing reported.
3. configure already probed for pledge without ever using the result; added the matching unveil probe and the two cmake checks so both build systems set the guards.

Hosts that lack pledge/unveil keep the no-op macros and are unaffected.