### PR TITLE
cmake: use full sysconf path for OPENSSLDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,7 +520,7 @@ if(OPENSSLDIR STREQUAL "")
 	if(WIN32)
 		set(OPENSSLDIR "C:/Windows/libressl/ssl")
 	else()
-		set(OPENSSLDIR "${CMAKE_INSTALL_SYSCONFDIR}/ssl")
+		set(OPENSSLDIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/ssl")
 	endif()
 
 	set(CONF_DIR "${CMAKE_INSTALL_SYSCONFDIR}/ssl")


### PR DESCRIPTION
`CMAKE_INSTALL_SYSCONFDIR` is relative to the install prefix by default. Using it for `OPENSSLDIR` causes `TLS_DEFAULT_CA_FILE` to be set to the relative path `etc/ssl/cert.pem`.

Use `CMAKE_INSTALL_FULL_SYSCONFDIR` for the runtime path while retaining `CMAKE_INSTALL_SYSCONFDIR` for the install destination.

Fix #1346