### PR TITLE
Build Emscripten targets in parallel

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -40,7 +40,7 @@ jobs:
         run: emcmake cmake -Bbuild
 
       - name: "Build"
-        run: cmake --build build --config Release
+        run: cmake --build build --config Release --parallel 4
 
       - name: "Test"
         run: ctest --test-dir build -C Release --output-on-failure
@@ -77,7 +77,7 @@ jobs:
           LDFLAGS: "-fsanitize=address"
 
       - name: "Build"
-        run: cmake --build build --config Release
+        run: cmake --build build --config Release --parallel 4
 
       - name: "Test"
         run: ctest --test-dir build -C Release --output-on-failure


### PR DESCRIPTION
Pass `--parallel` 4 to `cmake --build` for both the regular and ASAN Emscripten jobs.