### PR TITLE
Install CI dependencies in workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,6 +27,11 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: "Install build dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
       - name: "Run CI script"
         run: ./scripts/test
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,8 +48,29 @@ jobs:
 
       - name: "Install test dependencies"
         run: |
+          packages=(cmake ninja-build libio-socket-ssl-perl)
+          case "${{ matrix.arch }}" in
+            mingw32|mingw64)
+              packages+=(mingw-w64)
+              ;;
+            arm32)
+              packages+=(qemu-user-static binfmt-support g++-arm-linux-gnueabihf)
+              ;;
+            arm64)
+              packages+=(qemu-user-static binfmt-support g++-aarch64-linux-gnu)
+              ;;
+            loong64)
+              packages+=(qemu-user-static binfmt-support g++-14-loongarch64-linux-gnu)
+              ;;
+            mips32)
+              packages+=(qemu-user-static binfmt-support g++-mips-linux-gnu)
+              ;;
+            mips64)
+              packages+=(qemu-user-static binfmt-support g++-mips64el-linux-gnuabi64)
+              ;;
+          esac
           sudo apt-get update
-          sudo apt-get install -y libio-socket-ssl-perl
+          sudo apt-get install -y "${packages[@]}"
           perl -MIO::Socket::SSL::Utils -e 1
 
       - name: "Run tests"
@@ -77,7 +98,7 @@ jobs:
       - name: "Install test dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libio-socket-ssl-perl
+          sudo apt-get install -y cmake ninja-build libio-socket-ssl-perl
           perl -MIO::Socket::SSL::Utils -e 1
 
       - name: "Run tests"

--- a/scripts/test
+++ b/scripts/test
@@ -41,11 +41,6 @@ setup_cross_compiler() {
 	echo "##### Using $($CC --version | head -n 1)"
 }
 
-if type apt-get >/dev/null 2>&1; then
-	sudo apt-get update
-	sudo apt-get install -y cmake ninja-build
-fi
-
 # generate source tree
 ./autogen.sh
 
@@ -122,10 +117,6 @@ elif [ "$ARCH" = "mingw32" ] || [ "$ARCH" = "mingw64" ]; then
 		CPU=x86_64
 	fi
 
-	if ! type i686-w64-mingw32-gcc > /dev/null; then
-		sudo apt-get install -y mingw-w64
-	fi
-
 	./configure --host=$CPU-w64-mingw32
 	make -j 4
 
@@ -145,17 +136,13 @@ elif [ "$ARCH" = "mingw32" ] || [ "$ARCH" = "mingw64" ]; then
 	)
 
 elif [ "$ARCH" = "arm32" ] || [ "$ARCH" = "arm64" ]; then
-	sudo apt-get install -y qemu-user-static binfmt-support
-
 	if [ "$ARCH" = "arm32" ]; then
-		sudo apt-get install -y g++-arm-linux-gnueabihf
 		sudo ln -sf /usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.3 /lib/
 		setup_cross_compiler arm-linux-gnueabihf
 
 		./configure --host=arm-linux-gnueabihf
 		LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib make -j 4 check
 	else
-		sudo apt-get install -y g++-aarch64-linux-gnu
 		sudo ln -sf /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib/
 		setup_cross_compiler aarch64-linux-gnu
 
@@ -166,7 +153,6 @@ elif [ "$ARCH" = "arm32" ] || [ "$ARCH" = "arm64" ]; then
 	file apps/openssl/openssl
 
 elif [ "$ARCH" = "loong64" ]; then
-	sudo apt install -y qemu-user-static binfmt-support g++-14-loongarch64-linux-gnu
 	sudo ln -sf /usr/loongarch64-linux-gnu/lib64/ld-linux-loongarch-lp64d.so.1 /lib64
 	setup_cross_compiler loongarch64-linux-gnu
 
@@ -176,17 +162,13 @@ elif [ "$ARCH" = "loong64" ]; then
 	file apps/openssl/openssl
 
 elif [ "$ARCH" = "mips32" ] || [ "$ARCH" = "mips64" ]; then
-	sudo apt-get install -y qemu-user-static binfmt-support
-
 	if [ "$ARCH" = "mips32" ]; then
-		sudo apt-get install -y g++-mips-linux-gnu
 		sudo ln -sf /usr/mips-linux-gnu/lib/ld.so.1 /lib/
 		setup_cross_compiler mips-linux-gnu
 
 		./configure --host=mips-linux-gnu
 		LD_LIBRARY_PATH=/usr/mips-linux-gnu/lib make -j 4 check
 	else
-		sudo apt-get install -y g++-mips64el-linux-gnuabi64
 		sudo ln -sf /usr/mips64el-linux-gnuabi64/lib64/ld.so.1 /lib64
 		setup_cross_compiler mips64el-linux-gnuabi64
 


### PR DESCRIPTION
Move APT package installation from scripts/test to the CI workflows.

Build the Linux package list based on the target architecture so that CMake, Ninja, QEMU, and the required cross-compilers are installed together. This makes the packages required by each target explicit and avoids repeated apt-get operations within each CI job.