### PR TITLE
fix double free of lock in pthread_mutex_destroy

### DIFF
--- a/include/compat/pthread.h
+++ b/include/compat/pthread.h
@@ -110,8 +110,11 @@ pthread_mutex_unlock(pthread_mutex_t *mutex)
 static inline int
 pthread_mutex_destroy(pthread_mutex_t *mutex)
 {
-	DeleteCriticalSection(mutex->lock);
-	free(mutex->lock);
+	if (mutex->lock != NULL) {
+		DeleteCriticalSection(mutex->lock);
+		free(mutex->lock);
+		mutex->lock = NULL;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
pthread_mutex_lock lazily allocates the CRITICAL_SECTION into mutex->lock (NULL means not yet allocated), and PTHREAD_MUTEX_INITIALIZER starts it NULL. pthread_mutex_destroy accounted for neither:
- destroying a statically-initialized or never-locked mutex passes NULL to DeleteCriticalSection
- the freed pointer was left in place, so a second destroy double-frees it and a lock after destroy reuses freed memory

Guarding on non-NULL and clearing mutex->lock after the free keeps destroy consistent with the lazy-init the lock path already relies on.