### PR TITLE
set cloexec on the socket handle in win32 socketpair setfd

### DIFF
--- a/tests/compat/pipe2.c
+++ b/tests/compat/pipe2.c
@@ -18,9 +18,10 @@ static int setfd(int fd, int flag)
 {
 	int rc = -1;
 	if (flag & FD_CLOEXEC) {
-		HANDLE h = (HANDLE)_get_osfhandle(fd);
-		if (h != NULL)
-			rc = SetHandleInformation(h, HANDLE_FLAG_INHERIT, 0) == 0 ? -1 : 0;
+		/* fd is a Winsock SOCKET, not a CRT descriptor: use it as a
+		 * handle directly rather than translating with _get_osfhandle. */
+		HANDLE h = (HANDLE)(LONG_PTR)fd;
+		rc = SetHandleInformation(h, HANDLE_FLAG_INHERIT, 0) == 0 ? -1 : 0;
 	}
 	return rc;
 }


### PR DESCRIPTION
The win32 setfd() applies close-on-exec to the wrong object.

- the fd it gets is always a Winsock SOCKET (WSASocket/accept in socketpair, passed through bsd_socketpair and pipe2), never a CRT descriptor
- it runs that socket through _get_osfhandle, which takes a CRT descriptor index; for a socket that returns INVALID_HANDLE_VALUE, so HANDLE_FLAG_INHERIT is never cleared and the `h != NULL` guard does not catch it (the failure value is -1, not NULL)
- when the socket value collides with a live CRT descriptor (the same namespace overlap create_issue_1069_sentinels already works around) _get_osfhandle resolves to that unrelated file and inheritance gets cleared there instead, leaving the socket inheritable
- setfl right below already handles the same fd as a socket via ioctlsocket; do the same here and pass the socket to SetHandleInformation directly