### PR TITLE
update.sh: do not ignore git failures

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -30,6 +30,7 @@ fi
 set +e
 tag=`git describe --exact-match --tags HEAD 2>/dev/null`
 is_tag=$?
+set -e
 # adjust for 9 hour time delta between trees
 release_ts=$((`git show -s --format=%ct $tag|tail -1` + 32400))
 commit=`git -C openbsd rev-list -n 1 --before=$release_ts origin/$openbsd_branch`
@@ -45,7 +46,6 @@ else
   git -C openbsd checkout $openbsd_branch
   git -C openbsd pull
 fi
-set -e
 
 # setup source paths
 CWD=`pwd`


### PR DESCRIPTION
git describe is expected to fail when HEAD is not exactly at a tag. However, the set `+e` used for this check also allowed fetch, checkout, and pull failures to be ignored, causing less useful missing-file errors later in the script.

Re-enable set `-e` immediately after recording the git describe result so that subsequent Git operations fail at the actual error.