### PR TITLE
ci: use Visual Studio 2026 for Windows ARM64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,10 +25,10 @@ jobs:
         arch: ["x64", "Win32"]
         shared: ["ON", "OFF"]
         include:
-          - os: "windows-11-arm"
+          - os: "windows-11-vs2026-arm"
             arch: "ARM64"
             shared: "ON"
-          - os: "windows-11-arm"
+          - os: "windows-11-vs2026-arm"
             arch: "ARM64"
             shared: "OFF"
     steps:


### PR DESCRIPTION
Switch the static and shared ARM64 jobs to the `windows-11-vs2026-arm` runner.