### PR TITLE
ci: run CTest in parallel

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -43,7 +43,7 @@ jobs:
         run: cmake --build build --config Release --parallel 4
 
       - name: "Test"
-        run: ctest --test-dir build -C Release --output-on-failure
+        run: ctest --test-dir build -C Release --parallel --output-on-failure
 
   # Test ASAN with and without ASM enabled.
   test-asan:
@@ -80,4 +80,4 @@ jobs:
         run: cmake --build build --config Release --parallel 4
 
       - name: "Test"
-        run: ctest --test-dir build -C Release --output-on-failure
+        run: ctest --test-dir build -C Release --parallel --output-on-failure

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -37,4 +37,4 @@ jobs:
          ninja
     - name: Test
       run: |
-         ninja test
+         CTEST_PARALLEL_LEVEL="" ninja test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: "Test"
         shell: cmd
-        run: ctest --test-dir build -C Release --output-on-failure
+        run: ctest --test-dir build -C Release --parallel --output-on-failure
 
       - name: "Upload build artifacts"
         if: always()

--- a/scripts/test
+++ b/scripts/test
@@ -11,6 +11,7 @@ if [ "$ARCH" = "mingw32" -o "$ARCH" = "mingw64" -o "$ARCH" = "arm32" ]; then
 fi
 
 ENABLE_ASM="${ENABLE_ASM:=ON}"
+export CTEST_PARALLEL_LEVEL="${CTEST_PARALLEL_LEVEL-}"
 
 # setup_cross_compiler sets up environment variables for cross-compilation with the given prefix.
 setup_cross_compiler() {


### PR DESCRIPTION
Run CTest with parallel jobs in the Windows, Emscripten, Fedora, and shared test-script paths to reduce test time.