### PR TITLE
zizmor: set persist-credentials: false

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Install build dependencies"
         run: |

--- a/.github/workflows/cmake-config.yml
+++ b/.github/workflows/cmake-config.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Setup Windows dependencies"
         if: runner.os == 'Windows'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Install test dependencies"
         run: |
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Install test dependencies"
         run: |

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -24,6 +24,8 @@ jobs:
       image: fedora:rawhide@sha256:0c1f63ed8fb818fad16cf6ae091598c410a21d2e1a9adf183beb93189299bfba
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Install dependencies
       run: |
         dnf -y install git make clang cmake ninja-build autoconf automake libtool diffutils patch gawk perl-IO-Socket-SSL

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Setup"
         run: |
@@ -51,6 +53,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Setup"
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Install test dependencies"
         run: |
@@ -100,6 +102,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Install test dependencies"
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,6 +34,8 @@ jobs:
 
     - name: "Checkout repository"
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: "Run tests"
       run: ./scripts/test

--- a/.github/workflows/rust-openssl.yml
+++ b/.github/workflows/rust-openssl.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Build LibreSSL"
         run: |

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Setup"
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: "Setup MSYS2"
         id: msys2


### PR DESCRIPTION
Per zizmor, actions/checkout should be followed by removal of credentials that
may have been saved to disk. Doing so fixes lots of whining such as:

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/android.yml:27:9
   |
27 |         - name: "Checkout repository"
   |  _________^
28 | |         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   | |________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
```