### PR TITLE
provide a vsyslog fallback in syslog_r instead of the header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,11 @@ if(HAVE_SYSLOG)
 	add_definitions(-DHAVE_SYSLOG)
 endif()
 
+check_function_exists(vsyslog HAVE_VSYSLOG)
+if(HAVE_VSYSLOG)
+	add_definitions(-DHAVE_VSYSLOG)
+endif()
+
 check_symbol_exists(timespecsub sys/time.h HAVE_TIMESPECSUB)
 if(HAVE_TIMESPECSUB)
 	add_definitions(-DHAVE_TIMESPECSUB)

--- a/crypto/compat/syslog_r.c
+++ b/crypto/compat/syslog_r.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include <syslog.h>
 
 void
@@ -14,6 +16,15 @@ void
 vsyslog_r(int pri, struct syslog_data *data, const char *fmt, va_list ap)
 {
 #ifdef HAVE_SYSLOG
+#ifdef HAVE_VSYSLOG
 	vsyslog(pri, fmt, ap);
+#else
+	char *msg = NULL;
+
+	if (vasprintf(&msg, fmt, ap) == -1)
+		return;
+	syslog(pri, "%s", msg);
+	free(msg);
+#endif
 #endif
 }

--- a/include/compat/syslog.h
+++ b/include/compat/syslog.h
@@ -36,23 +36,3 @@ void vsyslog_r(int, struct syslog_data *, const char *, va_list);
 #endif
 
 #endif
-
-#ifdef _AIX
-#ifdef HAVE_SYSLOG
-#include <stdlib.h>
-void vsyslog(int facility_priority, const char *format, va_list arglist) {
-	char *msg = NULL;
-	vasprintf(&msg, format, arglist);
-
-	if (!msg)
-		return;
-
-	syslog(facility_priority, "%s", msg);
-	free(msg);
-}
-#endif /* HAVE_SYSLOG */
-
-void vsyslog_r(int pri, struct syslog_data *data, const char *fmt, va_list ap) {
-	vsyslog(pri, fmt, ap);
-}
-#endif /* AIX */

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -26,7 +26,7 @@ AC_CHECK_FUNCS([asprintf freezero ftruncate getdelim getline memmem])
 AC_CHECK_FUNCS([readpassphrase reallocarray recallocarray])
 AC_CHECK_FUNCS([strcasecmp strlcat strlcpy strndup strnlen strsep strtonum])
 AC_CHECK_FUNCS([timegm _mkgmtime timespecsub])
-AC_CHECK_FUNCS([getopt getprogname syslog syslog_r])
+AC_CHECK_FUNCS([getopt getprogname syslog syslog_r vsyslog])
 AC_CACHE_CHECK([for getpagesize], ac_cv_func_getpagesize, [
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <unistd.h>


### PR DESCRIPTION
The AIX vsyslog fallback lives in the syslog.h header, which breaks the build there:

- syslog.h defines vsyslog() and vsyslog_r() as plain (non-static) functions, so every translation unit that includes it emits external definitions
- syslog_r.c includes syslog.h and also defines vsyslog_r(), so on AIX (no syslog_r, so the shim is compiled) vsyslog_r ends up defined twice in one object, and the header calls vasprintf() without pulling in stdio.h
- moved the fallback into syslog_r.c behind a new HAVE_VSYSLOG probe (autotools + cmake); when vsyslog is present the call path is unchanged, otherwise it formats with vasprintf and hands the result to syslog(pri, "%s", msg)

Fixes the AIX build failure reported in #1116.