### PR TITLE
use winsock's struct timeval in the msvc sys/time.h shim

### DIFF
--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -303,7 +303,7 @@ int gettimeofday(struct timeval *tp, void *tzp)
 	time = ((uint64_t)file_time.dwLowDateTime);
 	time += ((uint64_t)file_time.dwHighDateTime) << 32;
 
-	tp->tv_sec = (long long)((time - EPOCH) / 10000000L);
+	tp->tv_sec = (long)((time - EPOCH) / 10000000L);
 	tp->tv_usec = (long)(system_time.wMilliseconds * 1000);
 	return 0;
 }

--- a/include/compat/sys/time.h
+++ b/include/compat/sys/time.h
@@ -7,15 +7,14 @@
 #define LIBCRYPTOCOMPAT_SYS_TIME_H
 
 #ifdef _MSC_VER
+/*
+ * Use the winsock struct timeval: it is what <openssl/dtls1.h> gives
+ * callers of DTLSv1_get_timeout() and the dgram BIO ctrls, so libssl
+ * must be built against the same layout.
+ */
 #include <winsock2.h>
 
-#define timeval libressl_timeval
 #define gettimeofday libressl_gettimeofday
-
-struct timeval {
-	long long	tv_sec;
-	long		tv_usec;
-};
 
 int gettimeofday(struct timeval *tp, void *tzp);
 #else


### PR DESCRIPTION
The MSVC sys/time.h shim redefines struct timeval with a 64-bit tv_sec (#1078), but that struct crosses libssl's public ABI:
- DTLSv1_get_timeout() writes sizeof(struct timeval) into the caller's object; a consumer built against <openssl/dtls1.h> has winsock's 8 byte struct, so every call overruns it by 8 bytes and its tv_usec is never set
- BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT and the dgram recv/send timeout ctrls carry the same 16 vs 8 byte mismatch
- mingw builds already use winsock's definition, so MSVC now matches; the libressl_gettimeofday rename stays so libcrypto keeps exporting no bare gettimeofday

Cost: gettimeofday() is back to a 32-bit tv_sec on MSVC, as on mingw. The DTLS timers only do relative arithmetic; the one absolute-time user is def_time_cb in ts_rsp_sign.c, which would need a 64-bit clock API rather than a wider struct that the ABI pins at two longs.
