### PR TITLE
clamp read and write length to INT_MAX in win32 posix shims

### DIFF
--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -16,6 +16,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -221,6 +222,8 @@ ssize_t
 posix_read(int fd, void *buf, size_t count)
 {
 	ssize_t rc;
+	if (count > INT_MAX)
+		count = INT_MAX;
 	if (is_socket(fd)) {
 		if ((rc = recv(fd, buf, count, 0)) == SOCKET_ERROR) {
 			int err = WSAGetLastError();
@@ -236,6 +239,8 @@ ssize_t
 posix_write(int fd, const void *buf, size_t count)
 {
 	ssize_t rc;
+	if (count > INT_MAX)
+		count = INT_MAX;
 	if (is_socket(fd)) {
 		if ((rc = send(fd, buf, count, 0)) == SOCKET_ERROR) {
 			rc = wsa_errno(WSAGetLastError());


### PR DESCRIPTION
posix_read/posix_write are the process-wide read()/write() on Windows (win32netcompat.h maps read/write to them) and pass their size_t count straight into the int-length socket and CRT calls:
- recv/send take an int length, so a count at or past 2 GiB is narrowed at the call
- count == 4 GiB truncates to 0, so recv() returns 0 and the read loop reads it as a clean EOF
- 2 GiB truncates to INT_MIN and fails a valid buffer with WSAEFAULT; 4 GiB + 1024 sends 1024 and reports it as complete
Clamp count to INT_MAX in both shims before the call. POSIX allows read/write to move fewer bytes than requested so callers loop for the rest, and normal-sized I/O is unchanged.