### PR TITLE
report a failed connect as POLLERR in the win32 poll shim

### DIFF
--- a/apps/openssl/compat/poll_win.c
+++ b/apps/openssl/compat/poll_win.c
@@ -73,6 +73,8 @@ compute_select_revents(int fd, short events,
 			rc |= POLLHUP;
 		else if (conn_has_oob_data(fd))
 			rc |= POLLRDBAND | POLLPRI;
+		else
+			rc |= POLLERR;
 	}
 
 	return rc;


### PR DESCRIPTION
1. every polled socket is placed in exceptfds, and winsock reports a failed non-blocking connect only there, never in writefds.
2. compute_select_revents() maps an exceptfds hit to POLLHUP (a peer close, matched from four recv errors) or POLLPRI (OOB data); a failed connect surfaces as WSAECONNREFUSED/WSAENOTCONN, so it matches neither and revents comes back 0. The wait loop has already broken out on the select() result, so poll() returns 0 within one RTT and the connect error is dropped.

openssl(1) ocsp/s_client set the socket non-blocking, get EAGAIN from connect(), then poll for POLLOUT; a refused or reset peer makes poll() report a timeout instead of the error, and with an infinite timeout poll() returns 0 on every call. POSIX reports POLLERR for a pending socket error, so set it when a socket flagged in exceptfds is neither a clean close nor carrying OOB data.