### PR TITLE
fix overwrite guard in the openssldir install hook

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,7 @@ install-exec-hook:
 	fi; \
 	mkdir -p "$$OPENSSLDIR/certs"; \
 	for i in cert.pem openssl.cnf x509v3.cnf; do \
-		if [ ! -f "$$OPENSSLDIR/$i" ]; then \
+		if [ ! -f "$$OPENSSLDIR/$$i" ]; then \
 			$(INSTALL) -m 644 "$(srcdir)/$$i" "$$OPENSSLDIR/$$i"; \
 		else \
 			echo " $$OPENSSLDIR/$$i already exists, install will not overwrite"; \


### PR DESCRIPTION
**Install hook overwrites existing openssldir files**
The guard in install-exec-hook tests `-f "$$OPENSSLDIR/$i"` with a single dollar on `i`, so make expands it as an empty make variable and the shell checks the directory itself, which never passes `-f`. A repeat `make install` then replaces an existing cert.pem, openssl.cnf and x509v3.cnf with the shipped defaults instead of taking the "already exists, install will not overwrite" branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF1dHqnUEhmE44ucDtFmB2