### PR TITLE
ci: test against latest Emscripten release

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Setup emsdk"
         uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
-          version: "3.1.60"
+          version: "latest"
 
       - name: "Prepare repository"
         run: ./autogen.sh
@@ -69,7 +69,7 @@ jobs:
       - name: "Setup emsdk"
         uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
-          version: "3.1.60"
+          version: "latest"
 
       - name: "Prepare repository"
         run: ./autogen.sh
@@ -78,7 +78,7 @@ jobs:
         run: emcmake cmake -Bbuild
         env:
           CFLAGS: "-gsource-map -fsanitize=address"
-          LDFLAGS: "-fsanitize=address"
+          LDFLAGS: "-fsanitize=address -sALLOW_MEMORY_GROWTH"
 
       - name: "Build"
         run: cmake --build build --config Release --parallel 4

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,7 +68,7 @@ file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCE_DIR)
 function(prepare_emscripten_test_target TARGET_NAME)
 	if(EMSCRIPTEN)
 		set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS
-			"-sALLOW_MEMORY_GROWTH --preload-file ${TEST_SOURCE_DIR} ")
+			"-sALLOW_MEMORY_GROWTH -sNODERAWFS=1")
 	endif()
 endfunction()
 


### PR DESCRIPTION
Currently emscripten CI jobs were pinned to Emscripten 3.1.60.

This PR changes the Emscripten CI and test configuration to:

- Use the latest Emscripten release for both regular and ASAN builds.
- Enable memory growth for ASAN tests.

In addition, the ssl_verify test generates certificates on the host
filesystem at runtime and executes from the temporary directory containing
those certificates. The existing preloaded filesystem could not access these
runtime-generated files, and Node failed to open ssl_verify.data.

To address this issue, this PR uses Node's host filesystem for all Emscripten
tests, allowing ssl_verify to access runtime-generated certificates without
preloaded data files.