### PR TITLE
ci: test minimum and latest Android API levels

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,12 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Android 8-9"
-            min-nal: 26
-            max-nal: 28
-          - name: "Android 10-11"
-            min-nal: 29
-            max-nal: 30
+          - name: "Minimum API 26"
+            api-level: 26
+          - name: "Latest API"
+            api-level: latest
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -35,8 +33,8 @@ jobs:
           sudo apt-get install -y cmake ninja-build
 
       - name: "Run CI script"
-        run: ./scripts/test
+        run: |
+          ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME" ./scripts/test
         env:
           ARCH: "android"
-          MIN_NAL: "${{ matrix.min-nal }}"
-          MAX_NAL: "${{ matrix.max-nal }}"
+          ANDROID_API_LEVEL: "${{ matrix.api-level }}"

--- a/scripts/test
+++ b/scripts/test
@@ -193,38 +193,30 @@ elif [ "$ARCH" = "mips32" ] || [ "$ARCH" = "mips64" ]; then
 elif [ "$ARCH" = "android" ]; then
 	export TC_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake
 
-	# set target API level and architecture
-	level_arch=""
-	level=$MIN_NAL
-	while [ $level -le $MAX_NAL ]
+	# ANDROID_PLATFORM is the native minSdkVersion, not the Android version used
+	# to run tests. "latest" selects the newest API provided by the NDK.
+	if [ "$ANDROID_API_LEVEL" = "latest" ]; then
+		ANDROID_PLATFORM=latest
+	else
+		ANDROID_PLATFORM=android-$ANDROID_API_LEVEL
+	fi
+
+	# Build each architecture for the selected API level.
+	for ABI in x86_64 x86 arm64-v8a
 	do
-		level_arch="$level_arch $level;x86_64"
-		level_arch="$level_arch $level;x86"
-		level_arch="$level_arch $level;arm64-v8a"
-
-		level=`expr $level + 1`
-	done
-
-	echo "##### level_arch = $level_arch"
-
-	# build each API level and architecture
-	for la in $level_arch
-	do
-		NAL=`echo $la | cut -d ';' -f 1`
-		ABI=`echo $la | cut -d ';' -f 2`
 		echo ""
-		echo "##### Date: `date`, Native API level: $NAL, ABI: $ABI"
+		echo "##### Date: `date`, Native API level: $ANDROID_API_LEVEL, ABI: $ABI"
 
 		(
-		 build_dir=build-$NAL_$ABI
+		 build_dir=build-${ANDROID_API_LEVEL}_${ABI}
 		 rm -fr $build_dir
 		 mkdir $build_dir
 		 cd $build_dir
-		 echo "##### cmake -GNinja -DCMAKE_MAKE_PROGRAM=ninja -DANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_TOOLCHAIN_FILE=$TC_FILE -DANDROID_ABI=$ABI -DANDROID_NATIVE_API_LEVEL=$NAL .."
+		 echo "##### cmake -GNinja -DCMAKE_MAKE_PROGRAM=ninja -DANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_TOOLCHAIN_FILE=$TC_FILE -DANDROID_ABI=$ABI -DANDROID_PLATFORM=$ANDROID_PLATFORM .."
 		 cmake -GNinja -DCMAKE_MAKE_PROGRAM=ninja \
 		 -DANDROID_NDK=$ANDROID_NDK_HOME \
 		 -DCMAKE_TOOLCHAIN_FILE=$TC_FILE \
-		 -DANDROID_ABI=$ABI -DANDROID_NATIVE_API_LEVEL=$NAL \
+		 -DANDROID_ABI=$ABI -DANDROID_PLATFORM=$ANDROID_PLATFORM \
 		 -DENABLE_ASM=${ENABLE_ASM} ..
 
 		 ninja -j 4


### PR DESCRIPTION
Currently Android CI built every API level from 26 through 30 for each
supported ABI using the runner's default NDK.

This PR changes the CI to:

- Build each supported ABI against the minimum API level 26.
- Build each supported ABI against the latest API provided by the NDK.
- Use the latest NDK preinstalled on the GitHub Actions runner.
- Replace the MIN_NAL/MAX_NAL range with one API per job matrix.