### PR TITLE
return EINPROGRESS for in-progress connect in win32 shim

### DIFF
--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -197,8 +197,21 @@ int
 posix_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 	int rc = connect(sockfd, addr, addrlen);
-	if (rc == SOCKET_ERROR)
-		return wsa_errno(WSAGetLastError());
+	if (rc == SOCKET_ERROR) {
+		int err = WSAGetLastError();
+		/*
+		 * Winsock reports an in-progress non-blocking connect as
+		 * WSAEWOULDBLOCK. POSIX callers expect EINPROGRESS here; the
+		 * generic mapping returns EAGAIN, which on Windows is a
+		 * distinct value from both EINPROGRESS and EWOULDBLOCK, so the
+		 * connect looks like a hard failure instead.
+		 */
+		if (err == WSAEWOULDBLOCK) {
+			errno = EINPROGRESS;
+			return -1;
+		}
+		return wsa_errno(err);
+	}
 	return rc;
 }
 


### PR DESCRIPTION
Non-blocking connect() surfaces the wrong errno through the win32 shim.
- posix_connect maps Winsock WSAEWOULDBLOCK to EAGAIN via wsa_errno
- POSIX reports an in-progress non-blocking connect as EINPROGRESS
- on Windows EAGAIN (11), EWOULDBLOCK (140) and EINPROGRESS (112) are distinct values, so a caller checking errno == EINPROGRESS (or EWOULDBLOCK) after connect sees a hard failure
- handled in posix_connect so the generic WSAEWOULDBLOCK to EAGAIN mapping stays correct for recv/send